### PR TITLE
Corrige criação do QrCode PIX

### DIFF
--- a/bb_wrapper/services/pixcode.py
+++ b/bb_wrapper/services/pixcode.py
@@ -1,5 +1,6 @@
 from .brcode import BRCodeService
 from .qrcode import QRCodeService
+from .unicode import UnicodeService
 
 
 class PixCodeService:
@@ -61,10 +62,12 @@ class PixCodeService:
         data += BRCodeService().create_field_string(_id="58", value="BR")
 
         # campo ID 59 Merchant Name
+        nome_recebedor = nome_recebedor[:13]
+        nome_recebedor = UnicodeService().parse_unicode_to_alphanumeric(nome_recebedor)
         data += BRCodeService().create_field_string(_id="59", value=nome_recebedor)
 
         # campo ID 60 Merchant City
-        data += BRCodeService().create_field_string(_id="60", value="BRASILIA")
+        data += BRCodeService().create_field_string(_id="60", value="NATAL")
 
         # campo ID 62 Aditional Data Field
         # subcampo ID 05 Reference Label
@@ -79,6 +82,7 @@ class PixCodeService:
         # campo ID 63 CRC 16
         data_to_encode = data + "6304"
         crc_value = BRCodeService().crc_16_ccitt_ffff(data_to_encode)
+        crc_value = crc_value.zfill(4)
         data += BRCodeService().create_field_string(_id="63", value=crc_value)
 
         return data, QRCodeService().generate_qrcode_b64image(data)

--- a/bb_wrapper/wrapper/pix_cob.py
+++ b/bb_wrapper/wrapper/pix_cob.py
@@ -197,6 +197,7 @@ class PIXCobBBWrapper(BaseBBWrapper):
         nome_recebedor: str,
         valor: float,
         descricao: str,
+        info: list = None,
     ):
         """
         Criar uma cobrança PIX com QRCode dinâmico
@@ -211,7 +212,7 @@ class PIXCobBBWrapper(BaseBBWrapper):
             descricao: descrição da cobrança
         """
         data = self._create_and_validate_cobranca_data(
-            expiracao, chave, documento_devedor, nome_devedor, valor, descricao
+            expiracao, chave, documento_devedor, nome_devedor, valor, descricao, info
         )
         url = self._construct_url("cobqrcode", end_bar=True)
 

--- a/examples/pix_cob/listar_pix_2.py
+++ b/examples/pix_cob/listar_pix_2.py
@@ -6,6 +6,6 @@ from bb_wrapper.wrapper import PIXCobBBWrapper
 
 c = PIXCobBBWrapper()
 
-response = c.listar_pix(inicio="2020-11-10T00:00:00Z", fim="2020-11-10T23:59:59Z")
+response = c.listar_pix(inicio="2021-08-13T00:00:00Z", fim="2021-08-16T23:59:59Z")
 
 dump_response(response, os.path.basename(__file__).split(".")[0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.23.*
+requests==2.24.*
 python-decouple==3.*
 pydantic==1.7.*
 python-barcode==0.13.*

--- a/tests/services/test_pixcode.py
+++ b/tests/services/test_pixcode.py
@@ -18,7 +18,7 @@ class PIXCodeServiceTestCase(TestCase):
             - for chamado PixCodeService().create(location, recebedor)
         Então:
             - deve ser retornado result_data e result_qrcode
-            - result_data deve ser "00020101021226870014br.gov.bcb.pix2565qrcodepix-h.bb.com.br/pix/v2/0c3f04a0-a41a-401e-8bb6-f6744c75a6055204000053039865802BR5920ALAN GUIACHERO BUENO6008BRASILIA62070503***63042AC9"  # noqa
+            - result_data deve ser "00020101021226870014br.gov.bcb.pix2565qrcodepix-h.bb.com.br/pix/v2/0c3f04a0-a41a-401e-8bb6-f6744c75a6055204000053039865802BR5912ALANGUIACHER6005NATAL62070503***6304D592"  # noqa
             - result_qrcode deve ser QRCodeService().generate_qrcode_b64image(expected_data)
         """
         location = "qrcodepix-h.bb.com.br/pix/v2/0c3f04a0-a41a-401e-8bb6-f6744c75a605"
@@ -26,7 +26,32 @@ class PIXCodeServiceTestCase(TestCase):
 
         result_data, result_qrcode = PixCodeService().create(location, recebedor)
 
-        expected_data = """00020101021226870014br.gov.bcb.pix2565qrcodepix-h.bb.com.br/pix/v2/0c3f04a0-a41a-401e-8bb6-f6744c75a6055204000053039865802BR5920ALAN GUIACHERO BUENO6008BRASILIA62070503***63042AC9"""  # noqa
+        expected_data = """00020101021226870014br.gov.bcb.pix2565qrcodepix-h.bb.com.br/pix/v2/0c3f04a0-a41a-401e-8bb6-f6744c75a6055204000053039865802BR5912ALANGUIACHER6005NATAL62070503***6304D592"""  # noqa
+        expected_qrcode = QRCodeService().generate_qrcode_b64image(expected_data)
+
+        self.assertEqual(result_data, expected_data)
+        self.assertEqual(result_qrcode, expected_qrcode)
+
+    def test_create_2(self):
+        """
+        https://forum.developers.bb.com.br/t/duvida-sobre-a-criacao-do-qrcode-da-cobranca-pix/4503/3?u=rodrigo3  # noqa
+
+        Dado:
+            - um location = "qrcodepix.bb.com.br/pix/v2/e1503bee-684b-4952-ade3-78c0a47e1d0e"
+            - um recebedor = "IMOBANCO"
+        Quando:
+            - for chamado PixCodeService().create(location, recebedor)
+        Então:
+            - deve ser retornado result_data e result_qrcode
+            - result_data deve ser "00020101021226850014br.gov.bcb.pix2563qrcodepix.bb.com.br/pix/v2/e1503bee-684b-4952-ade3-78c0a47e1d0e5204000053039865802BR5908IMOBANCO6005NATAL62070503***63040965"  # noqa
+            - result_qrcode deve ser QRCodeService().generate_qrcode_b64image(expected_data)
+        """
+        location = "qrcodepix.bb.com.br/pix/v2/e1503bee-684b-4952-ade3-78c0a47e1d0e"
+        recebedor = "IMOBANCO"
+
+        result_data, result_qrcode = PixCodeService().create(location, recebedor)
+
+        expected_data = """00020101021226850014br.gov.bcb.pix2563qrcodepix.bb.com.br/pix/v2/e1503bee-684b-4952-ade3-78c0a47e1d0e5204000053039865802BR5908IMOBANCO6005NATAL62070503***63040965"""  # noqa
         expected_qrcode = QRCodeService().generate_qrcode_b64image(expected_data)
 
         self.assertEqual(result_data, expected_data)


### PR DESCRIPTION
O nome do recebedor só comporta 13 caracteres.

Além disso, só aceita UNICODE!