### PR TITLE
Corrige tratamento de erro de autenticação com a API BB

### DIFF
--- a/bb_wrapper/wrapper/bb.py
+++ b/bb_wrapper/wrapper/bb.py
@@ -213,6 +213,7 @@ class BaseBBWrapper(RequestsWrapper):
                 backoff_factor=0.1,
                 status_forcelist=[401, 429, 500, 502, 503, 504],
                 allowed_methods=frozenset(["POST"]),
+                raise_on_status=False,
             )
             session.mount("http://", HTTPAdapter(max_retries=retry_strategy))
             session.mount("https://", HTTPAdapter(max_retries=retry_strategy))
@@ -222,15 +223,6 @@ class BaseBBWrapper(RequestsWrapper):
             self._token_type = response.data["token_type"]
             self._token_time = datetime.now()
             return True
-            # attempts = 0
-            # while attempts < self.AUTH_MAX_RETRY_ATTEMPTS:
-            #     try:
-            #         attempts += 1
-            #         perform_auth()
-            #         return True
-            #     except HTTPError as err:
-            #         if attempts >= self.AUTH_MAX_RETRY_ATTEMPTS:
-            #             raise err
         return False
 
     def _delete(self, url, headers=None) -> requests.Response:

--- a/bb_wrapper/wrapper/bb.py
+++ b/bb_wrapper/wrapper/bb.py
@@ -206,18 +206,15 @@ class BaseBBWrapper(RequestsWrapper):
         }
         kwargs = dict(headers=header, verify=False, data=data)
 
-        def perform_auth():
+        if self.__should_authenticate():
             session = requests.Session()
-            retries = requests.adapters.Retry(total=self.AUTH_MAX_RETRY_ATTEMPTS, backoff_factor=0.1)
+            retries = requests.adapters.Retry(total=self.AUTH_MAX_RETRY_ATTEMPTS, backoff_factor=0.1, status_forcelist=[401])
             session.mount('http://', HTTPAdapter(max_retries=retries))
             response = session.post(url, **kwargs)
             response = self._process_response(response)
             self._access_token = response.data["access_token"]
             self._token_type = response.data["token_type"]
             self._token_time = datetime.now()
-
-        if self.__should_authenticate():
-            perform_auth()
             return True
             # attempts = 0
             # while attempts < self.AUTH_MAX_RETRY_ATTEMPTS:

--- a/bb_wrapper/wrapper/bb.py
+++ b/bb_wrapper/wrapper/bb.py
@@ -3,6 +3,7 @@ import threading
 
 from .request import RequestsWrapper, requests
 from ..constants import IS_SANDBOX, BASIC_TOKEN, GW_APP_KEY
+from requests import HTTPError
 
 
 class BaseBBWrapper(RequestsWrapper):
@@ -219,8 +220,9 @@ class BaseBBWrapper(RequestsWrapper):
                     attempts += 1
                     perform_auth()
                     return True
-                finally:
-                    continue
+                except HTTPError as err:
+                    if attempts >= self.MAX_ATTEMPTS:
+                        raise err
         return False
 
     def _delete(self, url, headers=None) -> requests.Response:

--- a/bb_wrapper/wrapper/bb.py
+++ b/bb_wrapper/wrapper/bb.py
@@ -20,7 +20,7 @@ class BaseBBWrapper(RequestsWrapper):
     SCOPE = ""
 
     TOKEN_EXPIRE_TIME = (10 * 60) - 30  # 9:30 minutos
-    MAX_ATTEMPTS = 5
+    AUTH_MAX_RETRY_ATTEMPTS = 5
 
     def __init__(
         self,

--- a/bb_wrapper/wrapper/bb.py
+++ b/bb_wrapper/wrapper/bb.py
@@ -185,19 +185,22 @@ class BaseBBWrapper(RequestsWrapper):
         is_token_missing = not self._access_token
         return is_token_missing or is_token_expired
 
-    def __authenticate(self):
-        """
-        https://forum.developers.bb.com.br/t/status-code-415-unsupported-media-type-somente-em-producao/1123
-
-        O endpoint oauth recebe application/x-www-form-urlencoded!
-        """
-        url = (
+    def __oauth_url(self):
+        return (
             f"{BaseBBWrapper.BASE_SCHEMA}"
             f"oauth"
             f'{".sandbox" if self._is_sandbox else ""}'
             f"{BaseBBWrapper.BASE_DOMAIN}"
             f"/oauth/token"
         )
+
+    def __authenticate(self):
+        """
+        https://forum.developers.bb.com.br/t/status-code-415-unsupported-media-type-somente-em-producao/1123
+
+        O endpoint oauth recebe application/x-www-form-urlencoded!
+        """
+        url = self.__oauth_url()
         header = {"Authorization": f"Basic {self.__basic_token}"}
 
         data = {

--- a/bb_wrapper/wrapper/bb.py
+++ b/bb_wrapper/wrapper/bb.py
@@ -215,13 +215,13 @@ class BaseBBWrapper(RequestsWrapper):
 
         if self.__should_authenticate():
             attempts = 0
-            while attempts < self.MAX_ATTEMPTS:
+            while attempts < self.AUTH_MAX_RETRY_ATTEMPTS:
                 try:
                     attempts += 1
                     perform_auth()
                     return True
                 except HTTPError as err:
-                    if attempts >= self.MAX_ATTEMPTS:
+                    if attempts >= self.AUTH_MAX_RETRY_ATTEMPTS:
                         raise err
         return False
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -268,6 +268,21 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "responses"
+version = "0.21.0"
+description = "A utility library for mocking out the `requests` Python library."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+requests = ">=2.0,<3.0"
+urllib3 = ">=1.25.10"
+
+[package.extras]
+tests = ["pytest (>=7.0.0)", "coverage (>=6.0.0)", "pytest-cov", "pytest-asyncio", "pytest-localserver", "flake8", "types-mock", "types-requests", "mypy"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -323,47 +338,113 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "d5129e8d40a70e0374b01f6b03340a320ec77ee4b2e367bd22ad1731ce7ba043"
+content-hash = "b9548724760f2b6dbd1d2e856ecec5038065bf845b970482c04c00bb9751d194"
 
 [metadata.files]
 black = []
-certifi = []
+certifi = [
+    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
+    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
+]
 charset-normalizer = [
     {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
     {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
 ]
-click = []
-colorama = []
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+colorama = [
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
 coverage = []
-crc = []
+crc = [
+    {file = "crc-1.2.0-py3-none-any.whl", hash = "sha256:311d9144bf966f72d89b512f460cef4e8a1fdf971683c73dd002bc0f6e2994e1"},
+    {file = "crc-1.2.0.tar.gz", hash = "sha256:1f7e797847e388535d3bbf6ca8e1a7c97c4cbd3d6d298033192f9936460c60c5"},
+]
 flake8 = []
 freezegun = []
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
-isort = []
+isort = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
+]
 mccabe = []
 mypy-extensions = []
 pathspec = []
-platformdirs = []
+platformdirs = [
+    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
+    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
 pycodestyle = []
 pycpfcnpj = []
-pydantic = []
+pydantic = [
+    {file = "pydantic-1.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c8098a724c2784bf03e8070993f6d46aa2eeca031f8d8a048dff277703e6e193"},
+    {file = "pydantic-1.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c320c64dd876e45254bdd350f0179da737463eea41c43bacbee9d8c9d1021f11"},
+    {file = "pydantic-1.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18f3e912f9ad1bdec27fb06b8198a2ccc32f201e24174cec1b3424dda605a310"},
+    {file = "pydantic-1.9.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c11951b404e08b01b151222a1cb1a9f0a860a8153ce8334149ab9199cd198131"},
+    {file = "pydantic-1.9.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:8bc541a405423ce0e51c19f637050acdbdf8feca34150e0d17f675e72d119580"},
+    {file = "pydantic-1.9.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e565a785233c2d03724c4dc55464559639b1ba9ecf091288dd47ad9c629433bd"},
+    {file = "pydantic-1.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:a4a88dcd6ff8fd47c18b3a3709a89adb39a6373f4482e04c1b765045c7e282fd"},
+    {file = "pydantic-1.9.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:447d5521575f18e18240906beadc58551e97ec98142266e521c34968c76c8761"},
+    {file = "pydantic-1.9.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:985ceb5d0a86fcaa61e45781e567a59baa0da292d5ed2e490d612d0de5796918"},
+    {file = "pydantic-1.9.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059b6c1795170809103a1538255883e1983e5b831faea6558ef873d4955b4a74"},
+    {file = "pydantic-1.9.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:d12f96b5b64bec3f43c8e82b4aab7599d0157f11c798c9f9c528a72b9e0b339a"},
+    {file = "pydantic-1.9.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ae72f8098acb368d877b210ebe02ba12585e77bd0db78ac04a1ee9b9f5dd2166"},
+    {file = "pydantic-1.9.1-cp36-cp36m-win_amd64.whl", hash = "sha256:79b485767c13788ee314669008d01f9ef3bc05db9ea3298f6a50d3ef596a154b"},
+    {file = "pydantic-1.9.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:494f7c8537f0c02b740c229af4cb47c0d39840b829ecdcfc93d91dcbb0779892"},
+    {file = "pydantic-1.9.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0f047e11febe5c3198ed346b507e1d010330d56ad615a7e0a89fae604065a0e"},
+    {file = "pydantic-1.9.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:969dd06110cb780da01336b281f53e2e7eb3a482831df441fb65dd30403f4608"},
+    {file = "pydantic-1.9.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:177071dfc0df6248fd22b43036f936cfe2508077a72af0933d0c1fa269b18537"},
+    {file = "pydantic-1.9.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:9bcf8b6e011be08fb729d110f3e22e654a50f8a826b0575c7196616780683380"},
+    {file = "pydantic-1.9.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a955260d47f03df08acf45689bd163ed9df82c0e0124beb4251b1290fa7ae728"},
+    {file = "pydantic-1.9.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9ce157d979f742a915b75f792dbd6aa63b8eccaf46a1005ba03aa8a986bde34a"},
+    {file = "pydantic-1.9.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0bf07cab5b279859c253d26a9194a8906e6f4a210063b84b433cf90a569de0c1"},
+    {file = "pydantic-1.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d93d4e95eacd313d2c765ebe40d49ca9dd2ed90e5b37d0d421c597af830c195"},
+    {file = "pydantic-1.9.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1542636a39c4892c4f4fa6270696902acb186a9aaeac6f6cf92ce6ae2e88564b"},
+    {file = "pydantic-1.9.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a9af62e9b5b9bc67b2a195ebc2c2662fdf498a822d62f902bf27cccb52dbbf49"},
+    {file = "pydantic-1.9.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fe4670cb32ea98ffbf5a1262f14c3e102cccd92b1869df3bb09538158ba90fe6"},
+    {file = "pydantic-1.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:9f659a5ee95c8baa2436d392267988fd0f43eb774e5eb8739252e5a7e9cf07e0"},
+    {file = "pydantic-1.9.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b83ba3825bc91dfa989d4eed76865e71aea3a6ca1388b59fc801ee04c4d8d0d6"},
+    {file = "pydantic-1.9.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1dd8fecbad028cd89d04a46688d2fcc14423e8a196d5b0a5c65105664901f810"},
+    {file = "pydantic-1.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02eefd7087268b711a3ff4db528e9916ac9aa18616da7bca69c1871d0b7a091f"},
+    {file = "pydantic-1.9.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7eb57ba90929bac0b6cc2af2373893d80ac559adda6933e562dcfb375029acee"},
+    {file = "pydantic-1.9.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:4ce9ae9e91f46c344bec3b03d6ee9612802682c1551aaf627ad24045ce090761"},
+    {file = "pydantic-1.9.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:72ccb318bf0c9ab97fc04c10c37683d9eea952ed526707fabf9ac5ae59b701fd"},
+    {file = "pydantic-1.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:61b6760b08b7c395975d893e0b814a11cf011ebb24f7d869e7118f5a339a82e1"},
+    {file = "pydantic-1.9.1-py3-none-any.whl", hash = "sha256:4988c0f13c42bfa9ddd2fe2f569c9d54646ce84adc5de84228cfe83396f3bd58"},
+    {file = "pydantic-1.9.1.tar.gz", hash = "sha256:1ed987c3ff29fff7fd8c3ea3a3ea877ad310aae2ef9889a119e22d3f2db0691a"},
+]
 pyflakes = []
 python-barcode = []
 python-dateutil = []
 python-decouple = []
-qrcode = []
+qrcode = [
+    {file = "qrcode-7.3.1.tar.gz", hash = "sha256:375a6ff240ca9bd41adc070428b5dfc1dcfbb0f2507f1ac848f6cded38956578"},
+]
 requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
+responses = []
 six = []
 toml = []
-tomli = []
-typing-extensions = []
-unidecode = []
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+]
+unidecode = [
+    {file = "Unidecode-1.3.4-py3-none-any.whl", hash = "sha256:afa04efcdd818a93237574791be9b2817d7077c25a068b00f8cff7baa4e59257"},
+    {file = "Unidecode-1.3.4.tar.gz", hash = "sha256:8e4352fb93d5a735c788110d2e7ac8e8031eb06ccbfe8d324ab71735015f9342"},
+]
 urllib3 = [
     {file = "urllib3-1.26.11-py2.py3-none-any.whl", hash = "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc"},
     {file = "urllib3-1.26.11.tar.gz", hash = "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ Unidecode = "^1.2.0"
 qrcode = "^7.3"
 crc = "^1.0.1"
 pycpfcnpj = "^1.5.1"
+responses = "^0.21.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.9.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ Unidecode = "^1.2.0"
 qrcode = "^7.3"
 crc = "^1.0.1"
 pycpfcnpj = "^1.5.1"
-responses = "^0.21.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.9.2"
@@ -84,6 +83,7 @@ black = "^22.3.0"
 coverage = {extras = ["toml"], version = "^5.5"}
 isort = "^5.9.2"
 freezegun = "1.1.0"
+responses = "^0.21.0"
 
 [tool.poetry.scripts]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -105,7 +105,7 @@ class MockedRequestsTestCase(TestCase):
         )
 
     @staticmethod
-    def build_fail_auth_response():
+    def build_auth_fail_response():
         return MockedRequestsTestCase.build_response_mock(
             401,
             data={

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -119,7 +119,7 @@ class MockedRequestsTestCase(TestCase):
 
         def request_auth(*args, **kwargs):
             call_count = self.mocked_auth_requests.post.call_count
-            return self.build_success_auth_response(call_count)
+            return self.build_auth_success_response(call_count)
 
         self.mocked_auth_requests.post.side_effect = request_auth
 
@@ -129,9 +129,9 @@ class MockedRequestsTestCase(TestCase):
         def request_auth(*args, **kwargs):
             call_count = self.mocked_auth_requests.post.call_count
             if call_count <= number_of_fails:
-                return self.build_fail_auth_response()
+                return self.build_auth_fail_response()
             else:
-                return self.build_success_auth_response(call_count)
+                return self.build_auth_success_response(call_count)
 
         self.mocked_auth_requests.post.side_effect = request_auth
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch
 import json
 import responses
+from responses import registries
 
 
 class BarcodeAndCodeLineTestCase(TestCase):
@@ -45,7 +46,9 @@ class MockedRequestsTestCase(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.mock_responses = responses.RequestsMock()
+        self.mock_responses = responses.RequestsMock(
+            registry=registries.OrderedRegistry
+        )
         self.mock_responses.start()
         self.addCleanup(self.mock_responses.stop)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -70,12 +70,16 @@ class MockedRequestsTestCase(TestCase):
         PIXCobBBWrapper().reset_data()
         CobrancasBBWrapper().reset_data()
 
-    def build_auth_success_response(self, call_count):
-        data = {
+    @staticmethod
+    def __auth_success_response(call_count):
+        return {
             "access_token": f"token_{call_count}",
             "token_type": "token_type",
             "expires_in": 600,
         }
+
+    def build_auth_success_response(self, call_count):
+        data = self.__auth_success_response(call_count)
 
         resp = self.build_mocked_response(201, data)
 
@@ -100,7 +104,6 @@ class MockedRequestsTestCase(TestCase):
         resp = MagicMock(
             code=status_code,
             status=status_code,
-            reason="foo??",
             strict=0,
             fp=io.BufferedReader(raw_io),  # noqa
             closed=False,
@@ -142,9 +145,15 @@ class MockedRequestsTestCase(TestCase):
 
         self.mocked_getresponse.side_effect = get_response
 
+    def _get_authorization_header(self):
+        return {
+            "Authorization": "token_type token_"
+            f"{self.mocked_getresponse.call_count}",
+        }
+
     def _get_headers(self):
         return {
-            "Authorization": f"token_type token_"
+            "Authorization": "token_type token_"
             f"{self.mocked_getresponse.call_count}",
             "Content-type": "application/json",
         }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -95,7 +95,7 @@ class MockedRequestsTestCase(TestCase):
         return response
 
     @staticmethod
-    def build_success_auth_response(call_count):
+    def build_auth_success_response(call_count):
         return MockedRequestsTestCase.build_response_mock(
             200,
             data={

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,8 +47,11 @@ class MockedRequestsTestCase(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.mock = responses.RequestsMock(registry=registries.OrderedRegistry)
-        self.mock.start()
+        self.mocked_responses = responses.RequestsMock(registry=registries.OrderedRegistry)
+        self.mocked_responses.start()
+        self.addCleanUp(self.mocked_responses.stop)
+        
+        self.addCleanUp(self.clear_data)
 
         self.set_auth()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,7 +50,9 @@ class MockedRequestsTestCase(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.get_conn_patcher = patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
+        self.get_conn_patcher = patch(
+            "urllib3.connectionpool.HTTPConnectionPool._get_conn"
+        )
         self.mocked_get_conn = self.get_conn_patcher.start()
         self.mocked_conn = self.mocked_get_conn.return_value
         self.mocked_getresponse = self.mocked_conn.getresponse
@@ -77,7 +79,7 @@ class MockedRequestsTestCase(TestCase):
         data = {
             "access_token": f"token_{call_count}",
             "token_type": "token_type",
-            "expires_in": 600
+            "expires_in": 600,
         }
 
         resp = self.build_mocked_response(201, data)
@@ -103,7 +105,7 @@ class MockedRequestsTestCase(TestCase):
         resp = MagicMock(
             code=status_code,
             status=status_code,
-            reason='foo??',
+            reason="foo??",
             strict=0,
             fp=io.BufferedReader(raw_io),  # noqa
             closed=False,
@@ -130,12 +132,10 @@ class MockedRequestsTestCase(TestCase):
         """
         self.mocked_getresponse.reset_mock()
 
-        # number_of_retries_to_success += 1
-
         def get_response(*args, **kwargs):
             call_count = self.mocked_getresponse.call_count
 
-            passed_retries = number_of_retries_to_success <= call_count
+            passed_retries = number_of_retries_to_success < call_count
             verify = number_of_retries_to_success and passed_retries
             if verify:
                 return self.build_auth_success_response(call_count)

--- a/tests/wrapper/test_bb_base.py
+++ b/tests/wrapper/test_bb_base.py
@@ -5,7 +5,7 @@ from tests.utils import IsolatedEnvTestCase, MockedRequestsTestCase
 from bb_wrapper.wrapper.bb import BaseBBWrapper
 from bb_wrapper.wrapper.pix_cob import PIXCobBBWrapper
 
-from urllib3.util.retry import MaxRetryError
+from requests import HTTPError
 
 
 class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
@@ -19,9 +19,12 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
             - for chamado BaseBBWrapper()._BaseBBWrapper__authenticate()
         Então:
             - o resultado de uma autenticação bem sucedida deve ser True
+            - apenas uma requisição deve ser realizada
         """
         result = BaseBBWrapper()._BaseBBWrapper__authenticate()
+
         self.assertTrue(result)
+        self.mocked_getresponse.assert_called_once()
 
     def test_reauthentication(self):
         """
@@ -35,6 +38,8 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
             - uma nova autenticação deve ser realizada
             - o wrapper deve ter um novo token de autenticação
         """
+        total_requests = 2
+
         bb_wrapper = BaseBBWrapper()
 
         result = bb_wrapper._BaseBBWrapper__authenticate()
@@ -51,6 +56,8 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
             self.assertTrue(result)
             self.assertEqual(bb_wrapper._access_token, "token_2")
 
+        self.assertEqual(total_requests, self.mocked_getresponse.call_count)
+
     def test_authentication_for_multiple_instances(self):
         """
         Teste para verificar se o token de autenticação é utilizado
@@ -66,46 +73,47 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
         """
         bb_wrapper1 = BaseBBWrapper()
         result1 = bb_wrapper1._BaseBBWrapper__authenticate()
+
         self.assertEqual(result1, True)
         self.assertEqual(bb_wrapper1._access_token, "token_1")
 
         bb_wrapper2 = BaseBBWrapper()
         result2 = bb_wrapper2._BaseBBWrapper__authenticate()
+
         self.assertEqual(result2, False)
         self.assertEqual(bb_wrapper2._access_token, "token_1")
 
-        self.assertEqual(
-            bb_wrapper1._token_time,
-            bb_wrapper2._token_time,
-        )
+        self.assertEqual(bb_wrapper1._token_time, bb_wrapper2._token_time)
 
-        # self.mocked_auth_requests.Session().post.assert_called_once()
+        self.mocked_getresponse.assert_called_once()
 
     def test_authentication_multiple_wrappers(self):
         """
         Dado:
             - um wrapper BaseBBWrapper
             - outro wrapper PIXCobBBWrapper
-        quando:
+        Quando:
             - BaseBBWrapper se autenticar
             - PIXCobBBWrapper se autenticar
-        então:
+        Então:
             - cada wrapper deve ter um token diferente
         """
+        total_requests = 2
+
         wrapper1 = BaseBBWrapper()
         wrapper2 = PIXCobBBWrapper()
 
-        self.assertNotEqual(
-            wrapper1._data,
-            wrapper2._data,
-        )
+        self.assertNotEqual(wrapper1._data, wrapper2._data)
 
         wrapper1._BaseBBWrapper__authenticate()
+        wrapper2._BaseBBWrapper__authenticate()
+
+        self.assertNotEqual(wrapper1._access_token, wrapper2._access_token)
+
         self.assertEqual(wrapper1._access_token, "token_1")
+        self.assertEqual(wrapper2._access_token, "token_2")
 
-        self.assertEqual(wrapper2._access_token, None)
-
-        # self.mocked_auth_requests.Session().post.assert_called_once()
+        self.assertEqual(total_requests, self.mocked_getresponse.call_count)
 
     def test_authentication_fail_and_reauthentication(self):
         """
@@ -125,6 +133,7 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
 
         fail_attempts = 1
         total_attempts = fail_attempts + 1
+
         self.set_auth(fail_attempts)
 
         result = bb_wrapper._BaseBBWrapper__authenticate()
@@ -143,17 +152,17 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
             - for chamado BaseBBWrapper()._BaseBBWrapper__authenticate()
         Então:
             - o máximo de tentativas de autenticação devem ser realizadas
-            - o resultado da autenticação deve ser False
+            - a autenticação deve terminar em um lançamento de exceção HTTPError
         """
         bb_wrapper = BaseBBWrapper()
 
-        fail_attempts = bb_wrapper.AUTH_MAX_RETRY_ATTEMPTS
-        total_attempts = fail_attempts + 1
-        self.set_auth(fail_attempts)
+        total_attempts = bb_wrapper.AUTH_MAX_RETRY_ATTEMPTS + 1
 
-        with self.assertRaises(MaxRetryError) as ctx:
+        self.set_auth(-1)
+
+        with self.assertRaises(HTTPError) as ctx:
             bb_wrapper._BaseBBWrapper__authenticate()
         response = ctx.exception.response
-        self.assertEqual(response.status_code, 401, msg=response.data)
 
+        self.assertEqual(response.status_code, 401, msg=response.data)
         self.assertEqual(total_attempts, self.mocked_getresponse.call_count)

--- a/tests/wrapper/test_bb_base.py
+++ b/tests/wrapper/test_bb_base.py
@@ -152,10 +152,10 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
 
         self.set_fail_auth(fail_attempts)
 
-        try:
+        with self.assertRaises(HTTPError) as ctx:
             bb_wrapper._BaseBBWrapper__authenticate()
-        except HTTPError as err:
-            response = err.response
-            self.assertEqual(response.status_code, 401, msg=response.data)
+        response = ctx.exception.response
+        self.assertEqual(response.status_code, 401, msg=response.data)
+            
 
         self.assertEqual(total_attempts, self.mocked_auth_requests.post.call_count)

--- a/tests/wrapper/test_bb_base.py
+++ b/tests/wrapper/test_bb_base.py
@@ -131,7 +131,7 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
 
         self.assertTrue(result)
         self.assertEqual(total_attempts, self.mocked_auth_requests.post.call_count)
-        self.assertEqual(bb_wrapper._token, 'token_2')
+        self.assertEqual(bb_wrapper._access_token, 'token_2')
 
     def test_authentication_fail_and_reauthentication_fail_after_5_attempts(self):
         """
@@ -147,7 +147,7 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
         """
         bb_wrapper = BaseBBWrapper()
 
-        fail_attempts = bb_wrapper.MAX_ATTEMPTS
+        fail_attempts = bb_wrapper.AUTH_MAX_RETRY_ATTEMPTS
         total_attempts = fail_attempts
 
         self.set_fail_auth(fail_attempts)

--- a/tests/wrapper/test_bb_base.py
+++ b/tests/wrapper/test_bb_base.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from tests.utils import IsolatedEnvTestCase, MockedRequestsTestCase
 from bb_wrapper.wrapper.bb import BaseBBWrapper
 from bb_wrapper.wrapper.pix_cob import PIXCobBBWrapper
+from requests import HTTPError
 
 
 class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
@@ -150,7 +151,10 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
 
         self.set_fail_auth(fail_attempts)
 
-        result = bb_wrapper._BaseBBWrapper__authenticate()
+        try:
+            bb_wrapper._BaseBBWrapper__authenticate()
+        except HTTPError as err:
+            response = err.response
+            self.assertEqual(response.status_code, 401, msg=response.data)
 
-        self.assertFalse(result)
         self.assertEqual(total_attempts, self.mocked_auth_requests.post.call_count)

--- a/tests/wrapper/test_bb_base.py
+++ b/tests/wrapper/test_bb_base.py
@@ -126,6 +126,7 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
         fail_attempts = 3
 
         self.set_auth(fail_attempts)
+        self.get_conn_patcher.stop()
 
         result = bb_wrapper._BaseBBWrapper__authenticate()
 

--- a/tests/wrapper/test_bb_base.py
+++ b/tests/wrapper/test_bb_base.py
@@ -131,6 +131,7 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
 
         self.assertTrue(result)
         self.assertEqual(total_attempts, self.mocked_auth_requests.post.call_count)
+        self.assertEqual(bb_wrapper._token, 'token_2')
 
     def test_authentication_fail_and_reauthentication_fail_after_5_attempts(self):
         """

--- a/tests/wrapper/test_bb_base.py
+++ b/tests/wrapper/test_bb_base.py
@@ -1,7 +1,7 @@
 from freezegun import freeze_time
 from datetime import timedelta
 
-from tests.utils import IsolatedEnvTestCase, MockedRequestsTestCase, MockedAuthenticationTestCase
+from tests.utils import IsolatedEnvTestCase, MockedRequestsTestCase
 from bb_wrapper.wrapper.bb import BaseBBWrapper
 from bb_wrapper.wrapper.pix_cob import PIXCobBBWrapper
 
@@ -79,7 +79,7 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
             bb_wrapper2._token_time,
         )
 
-        self.mocked_auth_requests.Session().post.assert_called_once()
+        # self.mocked_auth_requests.Session().post.assert_called_once()
 
     def test_authentication_multiple_wrappers(self):
         """
@@ -105,7 +105,7 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
 
         self.assertEqual(wrapper2._access_token, None)
 
-        self.mocked_auth_requests.Session().post.assert_called_once()
+        # self.mocked_auth_requests.Session().post.assert_called_once()
 
     def test_authentication_fail_and_reauthentication(self):
         """
@@ -123,15 +123,15 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
         """
         bb_wrapper = BaseBBWrapper()
 
-        fail_attempts = 1
+        fail_attempts = 3
 
-        self.set_fail_auth(fail_attempts)
+        self.set_auth(fail_attempts)
 
         result = bb_wrapper._BaseBBWrapper__authenticate()
 
         self.assertTrue(result)
         self.assertEqual(bb_wrapper._access_token, 'token_1')
-        self.assertEqual(fail_attempts, self.mocked_retry.increment.post.call_count)
+        # self.assertEqual(fail_attempts, self.mocked_retry.increment.post.call_count)
 
     def test_authentication_fail_and_reauthentication_fail_after_5_attempts(self):
         """
@@ -150,45 +150,11 @@ class BaseBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
         fail_attempts = bb_wrapper.AUTH_MAX_RETRY_ATTEMPTS
         total_attempts = fail_attempts
 
-        self.set_fail_auth(fail_attempts - 1)
+        # self.set_fail_auth(fail_attempts - 1)
 
         with self.assertRaises(MaxRetryError) as ctx:
             bb_wrapper._BaseBBWrapper__authenticate()
-        response = ctx.exception.response
-        self.assertEqual(response.status_code, 401, msg=response.data)
-
-        self.assertEqual(total_attempts, self.mocked_auth_requests.Session().post.call_count)
-
-
-class AuthBBWrapperTestCase(IsolatedEnvTestCase, MockedAuthenticationTestCase):
-    def test_authentication(self):
-        result = BaseBBWrapper()._BaseBBWrapper__authenticate()
-        self.assertTrue(result)
-
-    def test_authentication_fail_and_reauthentication(self):
-        bb_wrapper = BaseBBWrapper()
-
-        fail_attempts = 1
-
-        self.set_fail_auth(fail_attempts)
-
-        result = bb_wrapper._BaseBBWrapper__authenticate()
-
-        self.assertTrue(result)
-        self.assertEqual(bb_wrapper._access_token, 'token_1')
-        self.assertEqual(fail_attempts, self.mocked_retry.call_count)
-
-    def test_authentication_fail_and_reauthentication_fail_after_5_attempts(self):
-        bb_wrapper = BaseBBWrapper()
-
-        fail_attempts = bb_wrapper.AUTH_MAX_RETRY_ATTEMPTS
-        total_attempts = fail_attempts
-
-        self.set_fail_auth(fail_attempts - 1)
-
-        with self.assertRaises(MaxRetryError) as ctx:
-            bb_wrapper._BaseBBWrapper__authenticate()
-        response = ctx.exception.response
-        self.assertEqual(response.status_code, 401, msg=response.data)
-
-        self.assertEqual(total_attempts, self.mocked_retry.call_count)
+        # response = ctx.exception.response
+        # self.assertEqual(response.status_code, 401, msg=response.data)
+        #
+        # self.assertEqual(total_attempts, self.mocked_auth_requests.Session().post.call_count)

--- a/tests/wrapper/test_pagamentos.py
+++ b/tests/wrapper/test_pagamentos.py
@@ -79,8 +79,6 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         """
         Teste para verificar a URL da requisição e dados
         """
-        expected_total_requests = 2
-
         request_url = PagamentoLoteBBWrapper()._construct_url("cancelar-pagamentos")
         expected_json = {
             "agenciaDebito": "2",
@@ -101,15 +99,13 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(expected_total_requests, self.total_requests())
+        self.assertEqual(2, self.total_requests())
         self.mock_responses.assert_call_count(request_url, 1)
 
     def test_cancelar_pagamento_2(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        expected_total_requests = 2
-
         request_url = PagamentoLoteBBWrapper()._construct_url("cancelar-pagamentos")
         expected_json = {
             "agenciaDebito": "2",
@@ -131,15 +127,13 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(expected_total_requests, self.total_requests())
+        self.assertEqual(2, self.total_requests())
         self.mock_responses.assert_call_count(request_url, 1)
 
     def test_liberar_pagamentos_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        expected_total_requests = 2
-
         request_url = PagamentoLoteBBWrapper()._construct_url("liberar-pagamentos")
         expected_json = {"numeroRequisicao": "1", "indicadorFloat": "N"}
         self.mock_responses.add(
@@ -155,15 +149,13 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(expected_total_requests, self.total_requests())
+        self.assertEqual(2, self.total_requests())
         self.mock_responses.assert_call_count(request_url, 1)
 
     def test_resgatar_lote_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        expected_total_requests = 2
-
         request_url = PagamentoLoteBBWrapper()._construct_url("1")
         expected_json = {}
         self.mock_responses.add(
@@ -179,15 +171,13 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(expected_total_requests, self.total_requests())
+        self.assertEqual(2, self.total_requests())
         self.mock_responses.assert_call_count(request_url, 1)
 
     def test_resgatar_lote_solicitacao_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        expected_total_requests = 2
-
         request_url = PagamentoLoteBBWrapper()._construct_url("1", "solicitacao")
         expected_json = {}
         self.mock_responses.add(
@@ -203,15 +193,13 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(expected_total_requests, self.total_requests())
+        self.assertEqual(2, self.total_requests())
         self.mock_responses.assert_call_count(request_url, 1)
 
     def test_listar_pagamentos_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        expected_total_requests = 2
-
         request_url = PagamentoLoteBBWrapper()._construct_url(
             "pagamentos", search={"dataInicio": "foo", "dataFim": "bar", "indice": 0}
         )
@@ -229,15 +217,13 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(expected_total_requests, self.total_requests())
+        self.assertEqual(2, self.total_requests())
         self.mock_responses.assert_call_count(request_url, 1)
 
     def test_cadastrar_transferencia_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        expected_total_requests = 2
-
         request_url = PagamentoLoteBBWrapper()._construct_url("lotes-transferencias")
         expected_json = {
             "numeroRequisicao": "1",
@@ -274,15 +260,13 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(expected_total_requests, self.total_requests())
+        self.assertEqual(2, self.total_requests())
         self.mock_responses.assert_call_count(request_url, 1)
 
     def test_consultar_transferencia_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        expected_total_requests = 2
-
         request_url = PagamentoLoteBBWrapper()._construct_url("transferencias", "1")
         expected_json = {}
         self.mock_responses.add(
@@ -298,15 +282,13 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(expected_total_requests, self.total_requests())
+        self.assertEqual(2, self.total_requests())
         self.mock_responses.assert_call_count(request_url, 1)
 
     def test_cadastrar_pagamento_boleto_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        expected_total_requests = 2
-
         request_url = PagamentoLoteBBWrapper()._construct_url("lotes-boletos")
         expected_json = {
             "numeroRequisicao": "1",
@@ -349,15 +331,13 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(expected_total_requests, self.total_requests())
+        self.assertEqual(2, self.total_requests())
         self.mock_responses.assert_call_count(request_url, 1)
 
     def test_consultar_pagamento_boleto_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        expected_total_requests = 2
-
         request_url = PagamentoLoteBBWrapper()._construct_url("boletos", "1")
         expected_json = {}
         self.mock_responses.add(
@@ -373,15 +353,13 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(expected_total_requests, self.total_requests())
+        self.assertEqual(2, self.total_requests())
         self.mock_responses.assert_call_count(request_url, 1)
 
     def test_cadastrar_pagamento_tributo_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        expected_total_requests = 2
-
         request_url = PagamentoLoteBBWrapper()._construct_url(
             "lotes-guias-codigo-barras"
         )
@@ -421,15 +399,13 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(expected_total_requests, self.total_requests())
+        self.assertEqual(2, self.total_requests())
         self.mock_responses.assert_call_count(request_url, 1)
 
     def test_consultar_pagamento_tributo_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        expected_total_requests = 2
-
         request_url = PagamentoLoteBBWrapper()._construct_url(
             "guias-codigo-barras", "1"
         )
@@ -447,5 +423,5 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(expected_total_requests, self.total_requests())
+        self.assertEqual(2, self.total_requests())
         self.mock_responses.assert_call_count(request_url, 1)

--- a/tests/wrapper/test_pagamentos.py
+++ b/tests/wrapper/test_pagamentos.py
@@ -29,7 +29,6 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
             json=response_oauth,
         )
 
-
     def test_construct_url_1(self):
         """
         Dado:

--- a/tests/wrapper/test_pagamentos.py
+++ b/tests/wrapper/test_pagamentos.py
@@ -88,7 +88,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
             "digitoVerificadorContaCorrente": "x",
             "listaPagamentos": [{"codigoPagamento": "1"}],
         }
-        self.mock.add(
+        self.mock_responses.add(
             responses.POST,
             request_url,
             headers=self._build_authorization_header(1),
@@ -102,7 +102,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(expected_json, response.json())
 
         self.assertEqual(expected_total_requests, self.total_requests())
-        self.mock.assert_call_count(request_url, 1)
+        self.mock_responses.assert_call_count(request_url, 1)
 
     def test_cancelar_pagamento_2(self):
         """
@@ -118,7 +118,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
             "listaPagamentos": [{"codigoPagamento": "1"}],
             "numeroContratoPagamento": "4",
         }
-        self.mock.add(
+        self.mock_responses.add(
             responses.POST,
             request_url,
             headers=self._build_authorization_header(1),
@@ -132,7 +132,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(expected_json, response.json())
 
         self.assertEqual(expected_total_requests, self.total_requests())
-        self.mock.assert_call_count(request_url, 1)
+        self.mock_responses.assert_call_count(request_url, 1)
 
     def test_liberar_pagamentos_1(self):
         """
@@ -142,7 +142,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         request_url = PagamentoLoteBBWrapper()._construct_url("liberar-pagamentos")
         expected_json = {"numeroRequisicao": "1", "indicadorFloat": "N"}
-        self.mock.add(
+        self.mock_responses.add(
             responses.POST,
             request_url,
             headers=self._build_authorization_header(1),
@@ -156,7 +156,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(expected_json, response.json())
 
         self.assertEqual(expected_total_requests, self.total_requests())
-        self.mock.assert_call_count(request_url, 1)
+        self.mock_responses.assert_call_count(request_url, 1)
 
     def test_resgatar_lote_1(self):
         """
@@ -166,7 +166,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         request_url = PagamentoLoteBBWrapper()._construct_url("1")
         expected_json = {}
-        self.mock.add(
+        self.mock_responses.add(
             responses.GET,
             request_url,
             headers=self._build_authorization_header(1),
@@ -180,7 +180,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(expected_json, response.json())
 
         self.assertEqual(expected_total_requests, self.total_requests())
-        self.mock.assert_call_count(request_url, 1)
+        self.mock_responses.assert_call_count(request_url, 1)
 
     def test_resgatar_lote_solicitacao_1(self):
         """
@@ -190,7 +190,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         request_url = PagamentoLoteBBWrapper()._construct_url("1", "solicitacao")
         expected_json = {}
-        self.mock.add(
+        self.mock_responses.add(
             responses.GET,
             request_url,
             headers=self._build_authorization_header(1),
@@ -204,7 +204,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(expected_json, response.json())
 
         self.assertEqual(expected_total_requests, self.total_requests())
-        self.mock.assert_call_count(request_url, 1)
+        self.mock_responses.assert_call_count(request_url, 1)
 
     def test_listar_pagamentos_1(self):
         """
@@ -216,7 +216,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
             "pagamentos", search={"dataInicio": "foo", "dataFim": "bar", "indice": 0}
         )
         expected_json = {}
-        self.mock.add(
+        self.mock_responses.add(
             responses.GET,
             request_url,
             headers=self._build_authorization_header(1),
@@ -230,7 +230,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(expected_json, response.json())
 
         self.assertEqual(expected_total_requests, self.total_requests())
-        self.mock.assert_call_count(request_url, 1)
+        self.mock_responses.assert_call_count(request_url, 1)
 
     def test_cadastrar_transferencia_1(self):
         """
@@ -259,7 +259,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
                 }
             ],
         }
-        self.mock.add(
+        self.mock_responses.add(
             responses.POST,
             request_url,
             headers=self._build_authorization_header(1),
@@ -275,7 +275,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(expected_json, response.json())
 
         self.assertEqual(expected_total_requests, self.total_requests())
-        self.mock.assert_call_count(request_url, 1)
+        self.mock_responses.assert_call_count(request_url, 1)
 
     def test_consultar_transferencia_1(self):
         """
@@ -285,7 +285,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         request_url = PagamentoLoteBBWrapper()._construct_url("transferencias", "1")
         expected_json = {}
-        self.mock.add(
+        self.mock_responses.add(
             responses.GET,
             request_url,
             headers=self._build_authorization_header(1),
@@ -299,7 +299,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(expected_json, response.json())
 
         self.assertEqual(expected_total_requests, self.total_requests())
-        self.mock.assert_call_count(request_url, 1)
+        self.mock_responses.assert_call_count(request_url, 1)
 
     def test_cadastrar_pagamento_boleto_1(self):
         """
@@ -325,7 +325,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
                 }
             ],
         }
-        self.mock.add(
+        self.mock_responses.add(
             responses.POST,
             request_url,
             headers=self._build_authorization_header(1),
@@ -350,7 +350,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(expected_json, response.json())
 
         self.assertEqual(expected_total_requests, self.total_requests())
-        self.mock.assert_call_count(request_url, 1)
+        self.mock_responses.assert_call_count(request_url, 1)
 
     def test_consultar_pagamento_boleto_1(self):
         """
@@ -360,7 +360,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         request_url = PagamentoLoteBBWrapper()._construct_url("boletos", "1")
         expected_json = {}
-        self.mock.add(
+        self.mock_responses.add(
             responses.GET,
             request_url,
             headers=self._build_authorization_header(1),
@@ -374,7 +374,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(expected_json, response.json())
 
         self.assertEqual(expected_total_requests, self.total_requests())
-        self.mock.assert_call_count(request_url, 1)
+        self.mock_responses.assert_call_count(request_url, 1)
 
     def test_cadastrar_pagamento_tributo_1(self):
         """
@@ -399,7 +399,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
                 }
             ],
         }
-        self.mock.add(
+        self.mock_responses.add(
             responses.POST,
             request_url,
             headers=self._build_authorization_header(1),
@@ -422,7 +422,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(expected_json, response.json())
 
         self.assertEqual(expected_total_requests, self.total_requests())
-        self.mock.assert_call_count(request_url, 1)
+        self.mock_responses.assert_call_count(request_url, 1)
 
     def test_consultar_pagamento_tributo_1(self):
         """
@@ -434,7 +434,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
             "guias-codigo-barras", "1"
         )
         expected_json = {}
-        self.mock.add(
+        self.mock_responses.add(
             responses.GET,
             request_url,
             headers=self._build_authorization_header(1),
@@ -448,4 +448,4 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(expected_json, response.json())
 
         self.assertEqual(expected_total_requests, self.total_requests())
-        self.mock.assert_call_count(request_url, 1)
+        self.mock_responses.assert_call_count(request_url, 1)

--- a/tests/wrapper/test_pagamentos.py
+++ b/tests/wrapper/test_pagamentos.py
@@ -425,7 +425,9 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
             json=response_oauth,
         )
 
-        request_url = PagamentoLoteBBWrapper()._construct_url("lotes-guias-codigo-barras")
+        request_url = PagamentoLoteBBWrapper()._construct_url(
+            "lotes-guias-codigo-barras"
+        )
         expected_json = {
             "numeroRequisicao": "1",
             "numeroAgenciaDebito": "2",
@@ -475,7 +477,9 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
             json=response_oauth,
         )
 
-        request_url = PagamentoLoteBBWrapper()._construct_url("guias-codigo-barras", "1")
+        request_url = PagamentoLoteBBWrapper()._construct_url(
+            "guias-codigo-barras", "1"
+        )
         expected_json = {}
         responses.add(
             responses.GET,

--- a/tests/wrapper/test_pagamentos.py
+++ b/tests/wrapper/test_pagamentos.py
@@ -1,3 +1,5 @@
+import responses
+
 from unittest.mock import MagicMock
 
 from pydantic import ValidationError
@@ -69,33 +71,53 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         mocked_model.assert_called_with(**expected_kwargs_call)
 
+    @responses.activate
     def test_cancelar_pagamento_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        PagamentoLoteBBWrapper().cancelar_pagamentos("1", "2", "3", "x")
+        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
+        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
+        responses.add(
+            responses.POST,
+            oauth_url,
+            json=response_oauth,
+        )
 
-        url = PagamentoLoteBBWrapper()._construct_url("cancelar-pagamentos")
-
+        request_url = PagamentoLoteBBWrapper()._construct_url("cancelar-pagamentos")
         expected_json = {
             "agenciaDebito": "2",
             "contaCorrenteDebito": "3",
             "digitoVerificadorContaCorrente": "x",
             "listaPagamentos": [{"codigoPagamento": "1"}],
         }
-
-        self.mocked_post.assert_called_with(
-            url, **self.get_request_complements(), json=expected_json
+        responses.add(
+            responses.POST,
+            request_url,
+            headers=self._get_authorization_header(),
+            json=expected_json,
         )
 
+        response = PagamentoLoteBBWrapper().cancelar_pagamentos("1", "2", "3", "x")
+
+        self.assertEqual(request_url, response.url)
+        self.assertEqual(self._get_headers(), response.headers)
+        self.assertEqual(expected_json, response.data)
+
+    @responses.activate
     def test_cancelar_pagamento_2(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        PagamentoLoteBBWrapper().cancelar_pagamentos("1", "2", "3", "x", "4")
+        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
+        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
+        responses.add(
+            responses.POST,
+            oauth_url,
+            json=response_oauth,
+        )
 
-        url = PagamentoLoteBBWrapper()._construct_url("cancelar-pagamentos")
-
+        request_url = PagamentoLoteBBWrapper()._construct_url("cancelar-pagamentos")
         expected_json = {
             "agenciaDebito": "2",
             "contaCorrenteDebito": "3",
@@ -103,67 +125,147 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
             "listaPagamentos": [{"codigoPagamento": "1"}],
             "numeroContratoPagamento": "4",
         }
-
-        self.mocked_post.assert_called_with(
-            url, **self.get_request_complements(), json=expected_json
+        responses.add(
+            responses.POST,
+            request_url,
+            headers=self._get_authorization_header(),
+            json=expected_json,
         )
 
+        response = PagamentoLoteBBWrapper().cancelar_pagamentos("1", "2", "3", "x", "4")
+
+        self.assertEqual(request_url, response.url)
+        self.assertEqual(self._get_headers(), response.headers)
+        self.assertEqual(expected_json, response.data)
+
+    @responses.activate
     def test_liberar_pagamentos_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        PagamentoLoteBBWrapper().liberar_pagamentos("1")
-
-        url = PagamentoLoteBBWrapper()._construct_url("liberar-pagamentos")
-
-        expected_json = {"numeroRequisicao": "1", "indicadorFloat": "N"}
-
-        self.mocked_post.assert_called_with(
-            url, **self.get_request_complements(), json=expected_json
+        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
+        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
+        responses.add(
+            responses.POST,
+            oauth_url,
+            json=response_oauth,
         )
 
+        request_url = PagamentoLoteBBWrapper()._construct_url("liberar-pagamentos")
+        expected_json = {"numeroRequisicao": "1", "indicadorFloat": "N"}
+        responses.add(
+            responses.POST,
+            request_url,
+            headers=self._get_authorization_header(),
+            json=expected_json,
+        )
+
+        response = PagamentoLoteBBWrapper().liberar_pagamentos("1")
+
+        self.assertEqual(request_url, response.url)
+        self.assertEqual(self._get_headers(), response.headers)
+        self.assertEqual(expected_json, response.data)
+
+    @responses.activate
     def test_resgatar_lote_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        PagamentoLoteBBWrapper().resgatar_lote("1")
+        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
+        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
+        responses.add(
+            responses.POST,
+            oauth_url,
+            json=response_oauth,
+        )
 
-        url = PagamentoLoteBBWrapper()._construct_url("1")
+        request_url = PagamentoLoteBBWrapper()._construct_url("1")
+        expected_json = {}
+        responses.add(
+            responses.GET,
+            request_url,
+            headers=self._get_authorization_header(),
+            json=expected_json,
+        )
 
-        self.mocked_get.assert_called_with(url, **self.get_request_complements())
+        response = PagamentoLoteBBWrapper().resgatar_lote("1")
 
+        self.assertEqual(request_url, response.url)
+        self.assertEqual(self._get_headers(), response.headers)
+        self.assertEqual(expected_json, response.data)
+
+    @responses.activate
     def test_resgatar_lote_solicitacao_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        PagamentoLoteBBWrapper().resgatar_lote_solicitacao("1")
+        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
+        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
+        responses.add(
+            responses.POST,
+            oauth_url,
+            json=response_oauth,
+        )
 
-        url = PagamentoLoteBBWrapper()._construct_url("1", "solicitacao")
+        request_url = PagamentoLoteBBWrapper()._construct_url("1", "solicitacao")
+        expected_json = {}
+        responses.add(
+            responses.GET,
+            request_url,
+            headers=self._get_authorization_header(),
+            json=expected_json,
+        )
 
-        self.mocked_get.assert_called_with(url, **self.get_request_complements())
+        response = PagamentoLoteBBWrapper().resgatar_lote_solicitacao("1")
 
+        self.assertEqual(request_url, response.url)
+        self.assertEqual(self._get_headers(), response.headers)
+        self.assertEqual(expected_json, response.data)
+
+    @responses.activate
     def test_listar_pagamentos_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        PagamentoLoteBBWrapper().listar_pagamentos("foo", "bar")
-
-        url = PagamentoLoteBBWrapper()._construct_url(
-            "pagamentos", search={"dataInicio": "foo", "dataFim": "bar", "indice": 0}
+        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
+        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
+        responses.add(
+            responses.POST,
+            oauth_url,
+            json=response_oauth,
         )
 
-        self.mocked_get.assert_called_with(url, **self.get_request_complements())
+        request_url = PagamentoLoteBBWrapper()._construct_url(
+            "pagamentos", search={"dataInicio": "foo", "dataFim": "bar", "indice": 0}
+        )
+        expected_json = {}
+        responses.add(
+            responses.GET,
+            request_url,
+            headers=self._get_authorization_header(),
+            json=expected_json,
+        )
 
+        response = PagamentoLoteBBWrapper().listar_pagamentos("foo", "bar")
+
+        self.assertEqual(request_url, response.url)
+        self.assertEqual(self._get_headers(), response.headers)
+        self.assertEqual(expected_json, response.data)
+
+    @responses.activate
     def test_cadastrar_transferencia_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        PagamentoLoteBBWrapper().cadastrar_transferencia(
-            "1", "2", "3", "4", "5", "6", "7", "8", "99391916180", "10", "11", "12"
+        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
+        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
+        responses.add(
+            responses.POST,
+            oauth_url,
+            json=response_oauth,
         )
 
-        url = PagamentoLoteBBWrapper()._construct_url("lotes-transferencias")
-
+        request_url = PagamentoLoteBBWrapper()._construct_url("lotes-transferencias")
         expected_json = {
             "numeroRequisicao": "1",
             "agenciaDebito": "2",
@@ -184,40 +286,63 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
                 }
             ],
         }
-
-        self.mocked_post.assert_called_with(
-            url, **self.get_request_complements(), json=expected_json
+        responses.add(
+            responses.POST,
+            request_url,
+            headers=self._get_authorization_header(),
+            json=expected_json,
         )
 
+        response = PagamentoLoteBBWrapper().cadastrar_transferencia(
+            "1", "2", "3", "4", "5", "6", "7", "8", "99391916180", "10", "11", "12"
+        )
+
+        self.assertEqual(request_url, response.url)
+        self.assertEqual(self._get_headers(), response.headers)
+        self.assertEqual(expected_json, response.data)
+
+    @responses.activate
     def test_consultar_transferencia_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        PagamentoLoteBBWrapper().consultar_transferencia("1")
+        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
+        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
+        responses.add(
+            responses.POST,
+            oauth_url,
+            json=response_oauth,
+        )
 
-        url = PagamentoLoteBBWrapper()._construct_url("transferencias", "1")
+        request_url = PagamentoLoteBBWrapper()._construct_url("transferencias", "1")
+        expected_json = {}
+        responses.add(
+            responses.GET,
+            request_url,
+            headers=self._get_authorization_header(),
+            json=expected_json,
+        )
 
-        self.mocked_get.assert_called_with(url, **self.get_request_complements())
+        response = PagamentoLoteBBWrapper().consultar_transferencia("1")
 
+        self.assertEqual(request_url, response.url)
+        self.assertEqual(self._get_headers(), response.headers)
+        self.assertEqual(expected_json, response.data)
+
+    @responses.activate
     def test_cadastrar_pagamento_boleto_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        PagamentoLoteBBWrapper().cadastrar_pagamento_boleto(
-            "1",
-            "2",
-            "3",
-            "4",
-            "34191873400000614011092306628112938349558000",
-            "99391916180",
-            "7",
-            "8",
-            "9",
-            "10",
+        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
+        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
+        responses.add(
+            responses.POST,
+            oauth_url,
+            json=response_oauth,
         )
 
-        url = PagamentoLoteBBWrapper()._construct_url("lotes-boletos")
-
+        request_url = PagamentoLoteBBWrapper()._construct_url("lotes-boletos")
         expected_json = {
             "numeroRequisicao": "1",
             "numeroAgenciaDebito": "2",
@@ -235,38 +360,72 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
                 }
             ],
         }
-
-        self.mocked_post.assert_called_with(
-            url, **self.get_request_complements(), json=expected_json
+        responses.add(
+            responses.POST,
+            request_url,
+            headers=self._get_authorization_header(),
+            json=expected_json,
         )
 
-    def test_consultar_pagamento_boleto_1(self):
-        """
-        Teste para verificar a URL da requisição e dados
-        """
-        PagamentoLoteBBWrapper().consultar_pagamento_boleto("1")
-
-        url = PagamentoLoteBBWrapper()._construct_url("boletos", "1")
-
-        self.mocked_get.assert_called_with(url, **self.get_request_complements())
-
-    def test_cadastrar_pagamento_tributo_1(self):
-        """
-        Teste para verificar a URL da requisição e dados
-        """
-        PagamentoLoteBBWrapper().cadastrar_pagamento_tributo(
+        response = PagamentoLoteBBWrapper().cadastrar_pagamento_boleto(
             "1",
             "2",
             "3",
             "4",
-            "85800000000600003282126307082112794112788193",
+            "34191873400000614011092306628112938349558000",
+            "99391916180",
             "7",
             "8",
             "9",
+            "10",
         )
 
-        url = PagamentoLoteBBWrapper()._construct_url("lotes-guias-codigo-barras")
+        self.assertEqual(request_url, response.url)
+        self.assertEqual(self._get_headers(), response.headers)
+        self.assertEqual(expected_json, response.data)
 
+    @responses.activate
+    def test_consultar_pagamento_boleto_1(self):
+        """
+        Teste para verificar a URL da requisição e dados
+        """
+        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
+        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
+        responses.add(
+            responses.POST,
+            oauth_url,
+            json=response_oauth,
+        )
+
+        request_url = PagamentoLoteBBWrapper()._construct_url("boletos", "1")
+        expected_json = {}
+        responses.add(
+            responses.GET,
+            request_url,
+            headers=self._get_authorization_header(),
+            json=expected_json,
+        )
+
+        response = PagamentoLoteBBWrapper().consultar_pagamento_boleto("1")
+
+        self.assertEqual(request_url, response.url)
+        self.assertEqual(self._get_headers(), response.headers)
+        self.assertEqual(expected_json, response.data)
+
+    @responses.activate
+    def test_cadastrar_pagamento_tributo_1(self):
+        """
+        Teste para verificar a URL da requisição e dados
+        """
+        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
+        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
+        responses.add(
+            responses.POST,
+            oauth_url,
+            json=response_oauth,
+        )
+
+        request_url = PagamentoLoteBBWrapper()._construct_url("lotes-guias-codigo-barras")
         expected_json = {
             "numeroRequisicao": "1",
             "numeroAgenciaDebito": "2",
@@ -281,17 +440,52 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
                 }
             ],
         }
-
-        self.mocked_post.assert_called_with(
-            url, **self.get_request_complements(), json=expected_json
+        responses.add(
+            responses.POST,
+            request_url,
+            headers=self._get_authorization_header(),
+            json=expected_json,
         )
 
+        response = PagamentoLoteBBWrapper().cadastrar_pagamento_tributo(
+            "1",
+            "2",
+            "3",
+            "4",
+            "85800000000600003282126307082112794112788193",
+            "7",
+            "8",
+            "9",
+        )
+
+        self.assertEqual(request_url, response.url)
+        self.assertEqual(self._get_headers(), response.headers)
+        self.assertEqual(expected_json, response.data)
+
+    @responses.activate
     def test_consultar_pagamento_tributo_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        PagamentoLoteBBWrapper().consultar_pagamento_tributo("1")
+        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
+        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
+        responses.add(
+            responses.POST,
+            oauth_url,
+            json=response_oauth,
+        )
 
-        url = PagamentoLoteBBWrapper()._construct_url("guias-codigo-barras", "1")
+        request_url = PagamentoLoteBBWrapper()._construct_url("guias-codigo-barras", "1")
+        expected_json = {}
+        responses.add(
+            responses.GET,
+            request_url,
+            headers=self._get_authorization_header(),
+            json=expected_json,
+        )
 
-        self.mocked_get.assert_called_with(url, **self.get_request_complements())
+        response = PagamentoLoteBBWrapper().consultar_pagamento_tributo("1")
+
+        self.assertEqual(request_url, response.url)
+        self.assertEqual(self._get_headers(), response.headers)
+        self.assertEqual(expected_json, response.data)

--- a/tests/wrapper/test_pagamentos.py
+++ b/tests/wrapper/test_pagamentos.py
@@ -16,19 +16,8 @@ from tests.utils import (
 
 class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
     maxDiff = None
-    SUCCESS_STATUS_CODE = 200
 
-    def setUp(self):
-        super().setUp()
-
-        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
-        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
-        responses.add(
-            responses.POST,
-            oauth_url,
-            json=response_oauth,
-        )
-
+    @MockedRequestsTestCase.no_auth
     def test_construct_url_1(self):
         """
         Dado:
@@ -48,6 +37,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         self.assertEqual(expected, result)
 
+    @MockedRequestsTestCase.no_auth
     def test_valida_lote_0(self):
         """
         Teste para verificar a validação do model Pydantic
@@ -57,6 +47,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         with self.assertRaises(ValidationError):
             PagamentoLoteBBWrapper()._valida_lote_data(LoteData, **kwargs)
 
+    @MockedRequestsTestCase.no_auth
     def test_valida_lote_1(self):
         """
         Teste para verificar a validação do model Pydantic
@@ -69,6 +60,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         mocked_model.assert_called_with(**kwargs)
 
+    @MockedRequestsTestCase.no_auth
     def test_valida_lote_2_remocao_convenio(self):
         """
         Teste para garantir a remoção do argumento convenio quando None
@@ -83,12 +75,11 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         mocked_model.assert_called_with(**expected_kwargs_call)
 
-    @responses.activate
     def test_cancelar_pagamento_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        total_requests = 2
+        expected_total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("cancelar-pagamentos")
         expected_json = {
@@ -97,10 +88,10 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
             "digitoVerificadorContaCorrente": "x",
             "listaPagamentos": [{"codigoPagamento": "1"}],
         }
-        responses.add(
+        self.mock.add(
             responses.POST,
             request_url,
-            headers=self._get_authorization_header(),
+            headers=self._build_authorization_header(1),
             json=expected_json,
         )
 
@@ -110,15 +101,14 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(total_requests, len(responses.calls))
-        responses.assert_call_count(request_url, 1)
+        self.assertEqual(expected_total_requests, self.total_requests())
+        self.mock.assert_call_count(request_url, 1)
 
-    @responses.activate
     def test_cancelar_pagamento_2(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        total_requests = 2
+        expected_total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("cancelar-pagamentos")
         expected_json = {
@@ -128,10 +118,10 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
             "listaPagamentos": [{"codigoPagamento": "1"}],
             "numeroContratoPagamento": "4",
         }
-        responses.add(
+        self.mock.add(
             responses.POST,
             request_url,
-            headers=self._get_authorization_header(),
+            headers=self._build_authorization_header(1),
             json=expected_json,
         )
 
@@ -141,22 +131,21 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(total_requests, len(responses.calls))
-        responses.assert_call_count(request_url, 1)
+        self.assertEqual(expected_total_requests, self.total_requests())
+        self.mock.assert_call_count(request_url, 1)
 
-    @responses.activate
     def test_liberar_pagamentos_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        total_requests = 2
+        expected_total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("liberar-pagamentos")
         expected_json = {"numeroRequisicao": "1", "indicadorFloat": "N"}
-        responses.add(
+        self.mock.add(
             responses.POST,
             request_url,
-            headers=self._get_authorization_header(),
+            headers=self._build_authorization_header(1),
             json=expected_json,
         )
 
@@ -166,22 +155,21 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(total_requests, len(responses.calls))
-        responses.assert_call_count(request_url, 1)
+        self.assertEqual(expected_total_requests, self.total_requests())
+        self.mock.assert_call_count(request_url, 1)
 
-    @responses.activate
     def test_resgatar_lote_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        total_requests = 2
+        expected_total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("1")
         expected_json = {}
-        responses.add(
+        self.mock.add(
             responses.GET,
             request_url,
-            headers=self._get_authorization_header(),
+            headers=self._build_authorization_header(1),
             json=expected_json,
         )
 
@@ -191,22 +179,21 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(total_requests, len(responses.calls))
-        responses.assert_call_count(request_url, 1)
+        self.assertEqual(expected_total_requests, self.total_requests())
+        self.mock.assert_call_count(request_url, 1)
 
-    @responses.activate
     def test_resgatar_lote_solicitacao_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        total_requests = 2
+        expected_total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("1", "solicitacao")
         expected_json = {}
-        responses.add(
+        self.mock.add(
             responses.GET,
             request_url,
-            headers=self._get_authorization_header(),
+            headers=self._build_authorization_header(1),
             json=expected_json,
         )
 
@@ -216,24 +203,23 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(total_requests, len(responses.calls))
-        responses.assert_call_count(request_url, 1)
+        self.assertEqual(expected_total_requests, self.total_requests())
+        self.mock.assert_call_count(request_url, 1)
 
-    @responses.activate
     def test_listar_pagamentos_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        total_requests = 2
+        expected_total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url(
             "pagamentos", search={"dataInicio": "foo", "dataFim": "bar", "indice": 0}
         )
         expected_json = {}
-        responses.add(
+        self.mock.add(
             responses.GET,
             request_url,
-            headers=self._get_authorization_header(),
+            headers=self._build_authorization_header(1),
             json=expected_json,
         )
 
@@ -243,15 +229,14 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(total_requests, len(responses.calls))
-        responses.assert_call_count(request_url, 1)
+        self.assertEqual(expected_total_requests, self.total_requests())
+        self.mock.assert_call_count(request_url, 1)
 
-    @responses.activate
     def test_cadastrar_transferencia_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        total_requests = 2
+        expected_total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("lotes-transferencias")
         expected_json = {
@@ -274,10 +259,10 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
                 }
             ],
         }
-        responses.add(
+        self.mock.add(
             responses.POST,
             request_url,
-            headers=self._get_authorization_header(),
+            headers=self._build_authorization_header(1),
             json=expected_json,
         )
 
@@ -289,22 +274,21 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(total_requests, len(responses.calls))
-        responses.assert_call_count(request_url, 1)
+        self.assertEqual(expected_total_requests, self.total_requests())
+        self.mock.assert_call_count(request_url, 1)
 
-    @responses.activate
     def test_consultar_transferencia_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        total_requests = 2
+        expected_total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("transferencias", "1")
         expected_json = {}
-        responses.add(
+        self.mock.add(
             responses.GET,
             request_url,
-            headers=self._get_authorization_header(),
+            headers=self._build_authorization_header(1),
             json=expected_json,
         )
 
@@ -314,15 +298,14 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(total_requests, len(responses.calls))
-        responses.assert_call_count(request_url, 1)
+        self.assertEqual(expected_total_requests, self.total_requests())
+        self.mock.assert_call_count(request_url, 1)
 
-    @responses.activate
     def test_cadastrar_pagamento_boleto_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        total_requests = 2
+        expected_total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("lotes-boletos")
         expected_json = {
@@ -342,10 +325,10 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
                 }
             ],
         }
-        responses.add(
+        self.mock.add(
             responses.POST,
             request_url,
-            headers=self._get_authorization_header(),
+            headers=self._build_authorization_header(1),
             json=expected_json,
         )
 
@@ -366,22 +349,21 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(total_requests, len(responses.calls))
-        responses.assert_call_count(request_url, 1)
+        self.assertEqual(expected_total_requests, self.total_requests())
+        self.mock.assert_call_count(request_url, 1)
 
-    @responses.activate
     def test_consultar_pagamento_boleto_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        total_requests = 2
+        expected_total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("boletos", "1")
         expected_json = {}
-        responses.add(
+        self.mock.add(
             responses.GET,
             request_url,
-            headers=self._get_authorization_header(),
+            headers=self._build_authorization_header(1),
             json=expected_json,
         )
 
@@ -391,15 +373,14 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(total_requests, len(responses.calls))
-        responses.assert_call_count(request_url, 1)
+        self.assertEqual(expected_total_requests, self.total_requests())
+        self.mock.assert_call_count(request_url, 1)
 
-    @responses.activate
     def test_cadastrar_pagamento_tributo_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        total_requests = 2
+        expected_total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url(
             "lotes-guias-codigo-barras"
@@ -418,10 +399,10 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
                 }
             ],
         }
-        responses.add(
+        self.mock.add(
             responses.POST,
             request_url,
-            headers=self._get_authorization_header(),
+            headers=self._build_authorization_header(1),
             json=expected_json,
         )
 
@@ -440,24 +421,23 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(total_requests, len(responses.calls))
-        responses.assert_call_count(request_url, 1)
+        self.assertEqual(expected_total_requests, self.total_requests())
+        self.mock.assert_call_count(request_url, 1)
 
-    @responses.activate
     def test_consultar_pagamento_tributo_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        total_requests = 2
+        expected_total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url(
             "guias-codigo-barras", "1"
         )
         expected_json = {}
-        responses.add(
+        self.mock.add(
             responses.GET,
             request_url,
-            headers=self._get_authorization_header(),
+            headers=self._build_authorization_header(1),
             json=expected_json,
         )
 
@@ -467,5 +447,5 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         self.assertEqual(self._get_headers(), response.headers)
         self.assertEqual(expected_json, response.json())
 
-        self.assertEqual(total_requests, len(responses.calls))
-        responses.assert_call_count(request_url, 1)
+        self.assertEqual(expected_total_requests, self.total_requests())
+        self.mock.assert_call_count(request_url, 1)

--- a/tests/wrapper/test_pagamentos.py
+++ b/tests/wrapper/test_pagamentos.py
@@ -16,6 +16,19 @@ from tests.utils import (
 
 class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
     maxDiff = None
+    SUCCESS_STATUS_CODE = 200
+
+    def setUp(self):
+        super().setUp()
+
+        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
+        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
+        responses.add(
+            responses.POST,
+            oauth_url,
+            json=response_oauth,
+        )
+
 
     def test_construct_url_1(self):
         """
@@ -76,13 +89,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         """
         Teste para verificar a URL da requisição e dados
         """
-        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
-        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
-        responses.add(
-            responses.POST,
-            oauth_url,
-            json=response_oauth,
-        )
+        total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("cancelar-pagamentos")
         expected_json = {
@@ -102,20 +109,17 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         self.assertEqual(request_url, response.url)
         self.assertEqual(self._get_headers(), response.headers)
-        self.assertEqual(expected_json, response.data)
+        self.assertEqual(expected_json, response.json())
+
+        self.assertEqual(total_requests, len(responses.calls))
+        responses.assert_call_count(request_url, 1)
 
     @responses.activate
     def test_cancelar_pagamento_2(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
-        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
-        responses.add(
-            responses.POST,
-            oauth_url,
-            json=response_oauth,
-        )
+        total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("cancelar-pagamentos")
         expected_json = {
@@ -136,20 +140,17 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         self.assertEqual(request_url, response.url)
         self.assertEqual(self._get_headers(), response.headers)
-        self.assertEqual(expected_json, response.data)
+        self.assertEqual(expected_json, response.json())
+
+        self.assertEqual(total_requests, len(responses.calls))
+        responses.assert_call_count(request_url, 1)
 
     @responses.activate
     def test_liberar_pagamentos_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
-        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
-        responses.add(
-            responses.POST,
-            oauth_url,
-            json=response_oauth,
-        )
+        total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("liberar-pagamentos")
         expected_json = {"numeroRequisicao": "1", "indicadorFloat": "N"}
@@ -164,20 +165,17 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         self.assertEqual(request_url, response.url)
         self.assertEqual(self._get_headers(), response.headers)
-        self.assertEqual(expected_json, response.data)
+        self.assertEqual(expected_json, response.json())
+
+        self.assertEqual(total_requests, len(responses.calls))
+        responses.assert_call_count(request_url, 1)
 
     @responses.activate
     def test_resgatar_lote_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
-        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
-        responses.add(
-            responses.POST,
-            oauth_url,
-            json=response_oauth,
-        )
+        total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("1")
         expected_json = {}
@@ -192,20 +190,17 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         self.assertEqual(request_url, response.url)
         self.assertEqual(self._get_headers(), response.headers)
-        self.assertEqual(expected_json, response.data)
+        self.assertEqual(expected_json, response.json())
+
+        self.assertEqual(total_requests, len(responses.calls))
+        responses.assert_call_count(request_url, 1)
 
     @responses.activate
     def test_resgatar_lote_solicitacao_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
-        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
-        responses.add(
-            responses.POST,
-            oauth_url,
-            json=response_oauth,
-        )
+        total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("1", "solicitacao")
         expected_json = {}
@@ -220,20 +215,17 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         self.assertEqual(request_url, response.url)
         self.assertEqual(self._get_headers(), response.headers)
-        self.assertEqual(expected_json, response.data)
+        self.assertEqual(expected_json, response.json())
+
+        self.assertEqual(total_requests, len(responses.calls))
+        responses.assert_call_count(request_url, 1)
 
     @responses.activate
     def test_listar_pagamentos_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
-        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
-        responses.add(
-            responses.POST,
-            oauth_url,
-            json=response_oauth,
-        )
+        total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url(
             "pagamentos", search={"dataInicio": "foo", "dataFim": "bar", "indice": 0}
@@ -250,20 +242,17 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         self.assertEqual(request_url, response.url)
         self.assertEqual(self._get_headers(), response.headers)
-        self.assertEqual(expected_json, response.data)
+        self.assertEqual(expected_json, response.json())
+
+        self.assertEqual(total_requests, len(responses.calls))
+        responses.assert_call_count(request_url, 1)
 
     @responses.activate
     def test_cadastrar_transferencia_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
-        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
-        responses.add(
-            responses.POST,
-            oauth_url,
-            json=response_oauth,
-        )
+        total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("lotes-transferencias")
         expected_json = {
@@ -299,20 +288,17 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         self.assertEqual(request_url, response.url)
         self.assertEqual(self._get_headers(), response.headers)
-        self.assertEqual(expected_json, response.data)
+        self.assertEqual(expected_json, response.json())
+
+        self.assertEqual(total_requests, len(responses.calls))
+        responses.assert_call_count(request_url, 1)
 
     @responses.activate
     def test_consultar_transferencia_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
-        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
-        responses.add(
-            responses.POST,
-            oauth_url,
-            json=response_oauth,
-        )
+        total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("transferencias", "1")
         expected_json = {}
@@ -327,20 +313,17 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         self.assertEqual(request_url, response.url)
         self.assertEqual(self._get_headers(), response.headers)
-        self.assertEqual(expected_json, response.data)
+        self.assertEqual(expected_json, response.json())
+
+        self.assertEqual(total_requests, len(responses.calls))
+        responses.assert_call_count(request_url, 1)
 
     @responses.activate
     def test_cadastrar_pagamento_boleto_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
-        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
-        responses.add(
-            responses.POST,
-            oauth_url,
-            json=response_oauth,
-        )
+        total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("lotes-boletos")
         expected_json = {
@@ -382,20 +365,17 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         self.assertEqual(request_url, response.url)
         self.assertEqual(self._get_headers(), response.headers)
-        self.assertEqual(expected_json, response.data)
+        self.assertEqual(expected_json, response.json())
+
+        self.assertEqual(total_requests, len(responses.calls))
+        responses.assert_call_count(request_url, 1)
 
     @responses.activate
     def test_consultar_pagamento_boleto_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
-        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
-        responses.add(
-            responses.POST,
-            oauth_url,
-            json=response_oauth,
-        )
+        total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url("boletos", "1")
         expected_json = {}
@@ -410,20 +390,17 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         self.assertEqual(request_url, response.url)
         self.assertEqual(self._get_headers(), response.headers)
-        self.assertEqual(expected_json, response.data)
+        self.assertEqual(expected_json, response.json())
+
+        self.assertEqual(total_requests, len(responses.calls))
+        responses.assert_call_count(request_url, 1)
 
     @responses.activate
     def test_cadastrar_pagamento_tributo_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
-        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
-        responses.add(
-            responses.POST,
-            oauth_url,
-            json=response_oauth,
-        )
+        total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url(
             "lotes-guias-codigo-barras"
@@ -462,20 +439,17 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         self.assertEqual(request_url, response.url)
         self.assertEqual(self._get_headers(), response.headers)
-        self.assertEqual(expected_json, response.data)
+        self.assertEqual(expected_json, response.json())
+
+        self.assertEqual(total_requests, len(responses.calls))
+        responses.assert_call_count(request_url, 1)
 
     @responses.activate
     def test_consultar_pagamento_tributo_1(self):
         """
         Teste para verificar a URL da requisição e dados
         """
-        oauth_url = PagamentoLoteBBWrapper()._BaseBBWrapper__oauth_url()
-        response_oauth = self._MockedRequestsTestCase__auth_success_response(1)
-        responses.add(
-            responses.POST,
-            oauth_url,
-            json=response_oauth,
-        )
+        total_requests = 2
 
         request_url = PagamentoLoteBBWrapper()._construct_url(
             "guias-codigo-barras", "1"
@@ -492,4 +466,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         self.assertEqual(request_url, response.url)
         self.assertEqual(self._get_headers(), response.headers)
-        self.assertEqual(expected_json, response.data)
+        self.assertEqual(expected_json, response.json())
+
+        self.assertEqual(total_requests, len(responses.calls))
+        responses.assert_call_count(request_url, 1)


### PR DESCRIPTION
# Resumo

Relacionado aos issues/prs:
- closes #43

Este PR trata de falhas dee autenticação com a API BB de forma a realizar, no máximo, 5 tentativas.


# Alterações de models
- [ ] Sim
- [x] Não

<!-- Alguma descrição dos models alterados -->


# Alterações de services
- [ ] Sim
- [x] Não

<!-- Alguma descrição dos services alterados -->


# Alterações de wrappers
- [x] Sim
- [ ] Não

<!-- Alguma descrição dos wrappers alterados -->

Foi adicionado a constante `MAX_ATTEMPTS` pra controlar o número de tentativas de autenticação com a API BB.