### PR TITLE
Corrige url da API de produção de Lotes de Pagamento

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
         python: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
@@ -66,7 +66,7 @@ jobs:
         run: make test
 
   coverage:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: test
     steps:
       - uses: actions/checkout@v2

--- a/bb_wrapper/wrapper/pagamento_lote.py
+++ b/bb_wrapper/wrapper/pagamento_lote.py
@@ -17,7 +17,7 @@ class PagamentoLoteBBWrapper(BaseBBWrapper):
     """
 
     SCOPE = "pagamentos-lote.lotes-requisicao pagamentos-lote.transferencias-info pagamentos-lote.transferencias-requisicao pagamentos-lote.cancelar-requisicao pagamentos-lote.devolvidos-info pagamentos-lote.lotes-info pagamentos-lote.pagamentos-guias-sem-codigo-barras-info pagamentos-lote.pagamentos-info pagamentos-lote.pagamentos-guias-sem-codigo-barras-requisicao pagamentos-lote.pagamentos-codigo-barras-info pagamentos-lote.boletos-requisicao pagamentos-lote.guias-codigo-barras-info pagamentos-lote.guias-codigo-barras-requisicao pagamentos-lote.transferencias-pix-info pagamentos-lote.transferencias-pix-requisicao pagamentos-lote.pix-info pagamentos-lote.boletos-info"  # noqa
-    BASE_PROD_ADITION = "-ip"
+    BASE_PROD_ADDITION = "-ip"
     BASE_DOMAIN = ".bb.com.br/pagamentos-lote/v1"
 
     def _valida_lote_data(self, model, **kwargs):

--- a/tests/wrapper/test_pagamentos.py
+++ b/tests/wrapper/test_pagamentos.py
@@ -26,12 +26,33 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
             - for chamado PagamentoLoteBBWrapper()._construct_url(end_bar=True)
         Então:
             - o resultado deve ter pelo menos o texto
-                'https://api.hm.bb.com.br/pagamentos-lote/v1/?gw-dev-app-key='
+                'https://api.sandbox.bb.com.br/pagamentos-lote/v1/?gw-dev-app-key='
         """
         result = PagamentoLoteBBWrapper()._construct_url(end_bar=True)
 
         expected = (
             f"https://api.sandbox.bb.com.br/pagamentos-lote/v1/"
+            f"?gw-dev-app-key={PagamentoLoteBBWrapper()._BaseBBWrapper__gw_app_key}"
+        )
+
+        self.assertEqual(expected, result)
+
+    @MockedRequestsTestCase.no_auth
+    def test_construct_url_prod(self):
+        """
+        Dado:
+            -
+        Quando:
+            - for chamado PagamentoLoteBBWrapper(is_sandbox=False)._construct_url(end_bar=True)
+        Então:
+            - o resultado deve ter pelo menos o texto
+                'https://api-ip.bb.com.br/pagamentos-lote/v1/?gw-dev-app-key='
+        """
+
+        result = PagamentoLoteBBWrapper(is_sandbox=False)._construct_url(end_bar=True)
+
+        expected = (
+            f"https://api-ip.bb.com.br/pagamentos-lote/v1/"
             f"?gw-dev-app-key={PagamentoLoteBBWrapper()._BaseBBWrapper__gw_app_key}"
         )
 

--- a/tests/wrapper/test_pagamentos.py
+++ b/tests/wrapper/test_pagamentos.py
@@ -43,7 +43,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
         Dado:
             -
         Quando:
-            - for chamado PagamentoLoteBBWrapper(is_sandbox=False)._construct_url(end_bar=True)
+            - for chamado PagamentoLoteBBWrapper(is_sandbox=False)._construct_url(end_bar=True)  # noqa
         Então:
             - o resultado deve ter pelo menos o texto
                 'https://api-ip.bb.com.br/pagamentos-lote/v1/?gw-dev-app-key='


### PR DESCRIPTION
# Resumo

- https://github.com/imobanco/bb-wrapper/pull/37

No PR #37 foi corrigido o nome do atributo `BaseBBWrapper.BASE_PROD_ADDITION` porém o nome do atributo não foi corrigido para os wrappers filhos!

Por causa disso, a url do wrapper de lotes de pagamento estava errada para produção!

