### PR TITLE
Handshake TLS com API do BB

### DIFF
--- a/bb_wrapper/wrapper/bb.py
+++ b/bb_wrapper/wrapper/bb.py
@@ -27,7 +27,7 @@ class BaseBBWrapper(RequestsWrapper):
         basic_token=None,
         is_sandbox=None,
         gw_app_key=None,
-        verify_https=False,
+        verify_https=True,
         cert=None,
     ):
         if is_sandbox is None:
@@ -207,7 +207,7 @@ class BaseBBWrapper(RequestsWrapper):
             "grant_type": "client_credentials",
             "scope": self.SCOPE,
         }
-        kwargs = dict(headers=header, verify=False, data=data)
+        kwargs = dict(headers=header, verify=self._verify_https, data=data)
 
         if self.__should_authenticate():
             session = requests.Session()

--- a/bb_wrapper/wrapper/cobrancas.py
+++ b/bb_wrapper/wrapper/cobrancas.py
@@ -19,15 +19,11 @@ class CobrancasBBWrapper(BaseBBWrapper):
         basic_token=None,
         is_sandbox=None,
         gw_app_key=None,
-        verify_https=False,
-        cert=None,
     ):
         super().__init__(
             basic_token=basic_token,
             is_sandbox=is_sandbox,
             gw_app_key=gw_app_key,
-            verify_https=verify_https,
-            cert=cert,
         )
 
         if convenio is None:

--- a/bb_wrapper/wrapper/request.py
+++ b/bb_wrapper/wrapper/request.py
@@ -16,10 +16,10 @@ class RequestsWrapper:
         __base_url: Url base para construir os requests
     """
 
-    def __init__(self, base_url, verify_https=False, cert=None):
+    def __init__(self, base_url, verify_https=True, cert=None):
         self.__base_url = base_url
         self.__cert = cert
-        self.__verify_https = verify_https
+        self._verify_https = verify_https
 
     @staticmethod
     def _process_response(response) -> requests.Response:
@@ -109,7 +109,7 @@ class RequestsWrapper:
 
         return dict(
             headers=headers,
-            verify=self.__verify_https,
+            verify=self._verify_https,
             cert=self.__cert,
         )
 

--- a/examples/auth/access_token.py
+++ b/examples/auth/access_token.py
@@ -2,6 +2,6 @@ from bb_wrapper.wrapper.bb import BaseBBWrapper
 
 
 wrapper = BaseBBWrapper()
-response = wrapper.authenticate()
+response = wrapper._BaseBBWrapper__authenticate()
 
-print(response.data)
+print(response)

--- a/examples/certificates/debug.py
+++ b/examples/certificates/debug.py
@@ -1,0 +1,19 @@
+import os
+import ssl
+import certifi
+from urllib.request import urlopen
+
+openssl_dir, openssl_cafile = os.path.split(
+    ssl.get_default_verify_paths().openssl_cafile
+)
+# no content in this folder
+os.listdir(openssl_dir)
+# non existent file
+print(os.path.exists(os.path.join(openssl_dir, openssl_cafile)))
+
+
+cafile = certifi.where()
+context = ssl.create_default_context(cafile=cafile)
+
+request = "https://example.com"
+urlopen(request, context=context)


### PR DESCRIPTION
# Resumo
A muito tempo no pr #32 colocamos uma flag `verify=False` para desabilitar o TLS do HTTPS devido a um erro de certificados na API BB.

Finalmente esse problema foi resolvido na infra do BB.

https://forum.developers.bb.com.br/t/conexao-https-com-api-s-do-bb-com-problema/22210/14

