### PR TITLE
Corrige erro de conexão "Connection reset by peer"

### DIFF
--- a/bb_wrapper/wrapper/request.py
+++ b/bb_wrapper/wrapper/request.py
@@ -1,3 +1,4 @@
+from time import sleep
 from json.decoder import JSONDecodeError
 
 import requests
@@ -117,6 +118,9 @@ class RequestsWrapper:
             cert=self.__cert,
         )
 
+    def _base_request(self):
+        sleep(0.01)
+
     def _delete(self, url, headers=None) -> requests.Response:
         """
         http delete
@@ -127,6 +131,7 @@ class RequestsWrapper:
         Returns:
             (:class:`.requests.Response`)
         """
+        self._base_request()
         request_info = self._get_request_info(headers)
         response = requests.delete(url, timeout=self.__timeout, **request_info)
         response = self._process_response(response)
@@ -142,6 +147,7 @@ class RequestsWrapper:
         Returns:
             (:class:`.requests.Response`)
         """
+        self._base_request()
         request_info = self._get_request_info(headers)
         response = requests.get(url, timeout=self.__timeout, **request_info)
         response = self._process_response(response)
@@ -160,6 +166,7 @@ class RequestsWrapper:
         Returns:
             (:class:`.requests.Response`)
         """
+        self._base_request()
         request_info = self._get_request_info(headers)
         if use_json:
             request_info["json"] = data
@@ -180,6 +187,7 @@ class RequestsWrapper:
         Returns:
             (:class:`.requests.Response`)
         """
+        self._base_request()
         request_info = self._get_request_info(headers)
         if use_json:
             request_info["json"] = data
@@ -190,6 +198,7 @@ class RequestsWrapper:
         return response
 
     def _patch(self, url, data, headers=None, use_json=True) -> requests.Response:
+        self._base_request()
         request_info = self._get_request_info(headers)
         if use_json:
             request_info["json"] = data

--- a/bb_wrapper/wrapper/request.py
+++ b/bb_wrapper/wrapper/request.py
@@ -15,17 +15,15 @@ logger = _get_logger("requests")
 def retry_request(counter=5):
     retry_request.counter = counter
 
-    def wrapper(http_method, *args, **kwargs):
-        from functools import wraps
+    def wrapper(func, *args, **kwargs):
 
-        @wraps(http_method)
-        def inner(self, *args, **kwargs):
+        def inner(*args, **kwargs):
             try:
-                return http_method(self, *args, **kwargs)
+                return func(*args, **kwargs)
             except (ConnectionError, ConnectionResetError, ProtocolError):
+                retry_request.counter -= 1
                 if retry_request.counter > 0:
-                    retry_request.counter -= 1
-                    return inner(self, *args, **kwargs)
+                    return inner(*args, **kwargs)
                 raise
 
         return inner

--- a/bb_wrapper/wrapper/request.py
+++ b/bb_wrapper/wrapper/request.py
@@ -6,7 +6,7 @@ import requests
 from requests import ConnectionError
 from urllib3.exceptions import ProtocolError
 
-from ..utils import _get_logger
+from bb_wrapper.utils import _get_logger
 
 
 logger = _get_logger("requests")

--- a/bb_wrapper/wrapper/request.py
+++ b/bb_wrapper/wrapper/request.py
@@ -15,12 +15,12 @@ logger = _get_logger("requests")
 def retry_request(counter=5):
     retry_request.counter = counter
 
-    def wrapper(func, *args, **kwargs):
-
+    def wrapper(func):
         def inner(*args, **kwargs):
             try:
+                sleep(0.01)
                 return func(*args, **kwargs)
-            except (ConnectionError, ConnectionResetError, ProtocolError):
+            except (ConnectionResetError, ConnectionError, ProtocolError):
                 retry_request.counter -= 1
                 if retry_request.counter > 0:
                     return inner(*args, **kwargs)
@@ -128,9 +128,6 @@ class RequestsWrapper:
     def _base_url(self):
         return self.__base_url
 
-    def _base_request(self):
-        sleep(0.01)
-
     def _get_request_info(self, headers=None):
         if not headers:
             headers = self._authorization_header_data
@@ -154,7 +151,6 @@ class RequestsWrapper:
         Returns:
             (:class:`.requests.Response`)
         """
-        self._base_request()
         request_info = self._get_request_info(headers)
         response = requests.delete(url, timeout=self.__timeout, **request_info)
         response = self._process_response(response)
@@ -171,7 +167,6 @@ class RequestsWrapper:
         Returns:
             (:class:`.requests.Response`)
         """
-        self._base_request()
         request_info = self._get_request_info(headers)
         response = requests.get(url, timeout=self.__timeout, **request_info)
         response = self._process_response(response)
@@ -191,7 +186,6 @@ class RequestsWrapper:
         Returns:
             (:class:`.requests.Response`)
         """
-        self._base_request()
         request_info = self._get_request_info(headers)
         if use_json:
             request_info["json"] = data
@@ -213,7 +207,6 @@ class RequestsWrapper:
         Returns:
             (:class:`.requests.Response`)
         """
-        self._base_request()
         request_info = self._get_request_info(headers)
         if use_json:
             request_info["json"] = data
@@ -225,7 +218,6 @@ class RequestsWrapper:
 
     @retry_request(counter=3)
     def _patch(self, url, data, headers=None, use_json=True) -> requests.Response:
-        self._base_request()
         request_info = self._get_request_info(headers)
         if use_json:
             request_info["json"] = data

--- a/bb_wrapper/wrapper/request.py
+++ b/bb_wrapper/wrapper/request.py
@@ -99,12 +99,15 @@ class RequestsWrapper:
         raise NotImplementedError("Must implement auth function!")
 
     @property
+    def _authorization_header_data(self):
+        return {"Authorization": self._auth}
+
+    @property
     def _base_url(self):
         return self.__base_url
 
-    @property
-    def _authorization_header_data(self):
-        return {"Authorization": self._auth}
+    def _base_request(self):
+        sleep(0.01)
 
     def _get_request_info(self, headers=None):
         if not headers:
@@ -117,9 +120,6 @@ class RequestsWrapper:
             verify=self._verify_https,
             cert=self.__cert,
         )
-
-    def _base_request(self):
-        sleep(0.01)
 
     def _delete(self, url, headers=None) -> requests.Response:
         """

--- a/bb_wrapper/wrapper/request.py
+++ b/bb_wrapper/wrapper/request.py
@@ -17,7 +17,8 @@ def retry_request(max_retries=5):
         def inner(*args, counter=None, **kwargs):
             counter = counter if counter is not None else max_retries
             try:
-                sleep(0.01)
+                sleep_time = random(1, 90)/100
+                sleep(sleep_time)
                 return func(*args, **kwargs)
             except (ConnectionResetError, ConnectionError, ProtocolError):
                 if counter > 0:

--- a/bb_wrapper/wrapper/request.py
+++ b/bb_wrapper/wrapper/request.py
@@ -1,3 +1,4 @@
+import random
 from time import sleep
 from json.decoder import JSONDecodeError
 
@@ -17,7 +18,7 @@ def retry_request(max_retries=5):
         def inner(*args, counter=None, **kwargs):
             counter = counter if counter is not None else max_retries
             try:
-                sleep_time = random(1, 90)/100
+                sleep_time = random.randint(1, 90) / 100
                 sleep(sleep_time)
                 return func(*args, **kwargs)
             except (ConnectionResetError, ConnectionError, ProtocolError):

--- a/examples/connection.py
+++ b/examples/connection.py
@@ -9,10 +9,7 @@ def run_process():
         c = PIXCobBBWrapper()
         c.listar_pix(page=0)
 
-    threads = [
-        threading.Thread(target=run_thread)
-        for i in range(3)
-    ]
+    threads = [threading.Thread(target=run_thread) for i in range(3)]
 
     for thread in threads:
         thread.start()
@@ -22,10 +19,7 @@ def run_process():
 
 
 while True:
-    ps = [
-        Process(target=run_process)
-        for i in range(10)
-    ]
+    ps = [Process(target=run_process) for i in range(10)]
 
     for p in ps:
         p.start()
@@ -33,7 +27,7 @@ while True:
     for p in ps:
         p.join(timeout=6)
         if p.exitcode is None:
-            print('vou matar', str(p))
+            print("vou matar", str(p))
             p.kill()
 
-    print('Estou tentando novamente!')
+    print("Estou tentando novamente!")

--- a/examples/connection.py
+++ b/examples/connection.py
@@ -1,0 +1,39 @@
+import threading
+from multiprocessing import Process
+
+from bb_wrapper.wrapper import PIXCobBBWrapper
+
+
+def run_process():
+    def run_thread():
+        c = PIXCobBBWrapper()
+        c.listar_pix(page=0)
+
+    threads = [
+        threading.Thread(target=run_thread)
+        for i in range(3)
+    ]
+
+    for thread in threads:
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+
+while True:
+    ps = [
+        Process(target=run_process)
+        for i in range(10)
+    ]
+
+    for p in ps:
+        p.start()
+
+    for p in ps:
+        p.join(timeout=6)
+        if p.exitcode is None:
+            print('vou matar', str(p))
+            p.kill()
+
+    print('Estou tentando novamente!')

--- a/poetry.lock
+++ b/poetry.lock
@@ -163,6 +163,14 @@ docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehint
 test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
 
 [[package]]
+name = "py-bdd-context"
+version = "0.0.2"
+description = "Biblioteca com Context Manager para facilitar os testes de Behavior Driven Development (BDD)"
+category = "dev"
+optional = false
+python-versions = ">=3.8,<4.0"
+
+[[package]]
 name = "pycodestyle"
 version = "2.7.0"
 description = "Python style guide checker"
@@ -271,7 +279,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 name = "responses"
 version = "0.21.0"
 description = "A utility library for mocking out the `requests` Python library."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -338,114 +346,38 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "b9548724760f2b6dbd1d2e856ecec5038065bf845b970482c04c00bb9751d194"
+content-hash = "407db878c845999151040627c86ff1a8d1c6fdbe5bc24c42138d6b3257dc3346"
 
 [metadata.files]
 black = []
-certifi = [
-    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
-    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
-]
-charset-normalizer = [
-    {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
-    {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
-]
-click = [
-    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
-    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
-]
-colorama = [
-    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
-    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
-]
+certifi = []
+charset-normalizer = []
+click = []
+colorama = []
 coverage = []
-crc = [
-    {file = "crc-1.2.0-py3-none-any.whl", hash = "sha256:311d9144bf966f72d89b512f460cef4e8a1fdf971683c73dd002bc0f6e2994e1"},
-    {file = "crc-1.2.0.tar.gz", hash = "sha256:1f7e797847e388535d3bbf6ca8e1a7c97c4cbd3d6d298033192f9936460c60c5"},
-]
+crc = []
 flake8 = []
 freezegun = []
-idna = [
-    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
-    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
-]
-isort = [
-    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
-    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
-]
+idna = []
+isort = []
 mccabe = []
 mypy-extensions = []
 pathspec = []
-platformdirs = [
-    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
-    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
-]
+platformdirs = []
+py-bdd-context = []
 pycodestyle = []
 pycpfcnpj = []
-pydantic = [
-    {file = "pydantic-1.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c8098a724c2784bf03e8070993f6d46aa2eeca031f8d8a048dff277703e6e193"},
-    {file = "pydantic-1.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c320c64dd876e45254bdd350f0179da737463eea41c43bacbee9d8c9d1021f11"},
-    {file = "pydantic-1.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18f3e912f9ad1bdec27fb06b8198a2ccc32f201e24174cec1b3424dda605a310"},
-    {file = "pydantic-1.9.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c11951b404e08b01b151222a1cb1a9f0a860a8153ce8334149ab9199cd198131"},
-    {file = "pydantic-1.9.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:8bc541a405423ce0e51c19f637050acdbdf8feca34150e0d17f675e72d119580"},
-    {file = "pydantic-1.9.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e565a785233c2d03724c4dc55464559639b1ba9ecf091288dd47ad9c629433bd"},
-    {file = "pydantic-1.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:a4a88dcd6ff8fd47c18b3a3709a89adb39a6373f4482e04c1b765045c7e282fd"},
-    {file = "pydantic-1.9.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:447d5521575f18e18240906beadc58551e97ec98142266e521c34968c76c8761"},
-    {file = "pydantic-1.9.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:985ceb5d0a86fcaa61e45781e567a59baa0da292d5ed2e490d612d0de5796918"},
-    {file = "pydantic-1.9.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059b6c1795170809103a1538255883e1983e5b831faea6558ef873d4955b4a74"},
-    {file = "pydantic-1.9.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:d12f96b5b64bec3f43c8e82b4aab7599d0157f11c798c9f9c528a72b9e0b339a"},
-    {file = "pydantic-1.9.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ae72f8098acb368d877b210ebe02ba12585e77bd0db78ac04a1ee9b9f5dd2166"},
-    {file = "pydantic-1.9.1-cp36-cp36m-win_amd64.whl", hash = "sha256:79b485767c13788ee314669008d01f9ef3bc05db9ea3298f6a50d3ef596a154b"},
-    {file = "pydantic-1.9.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:494f7c8537f0c02b740c229af4cb47c0d39840b829ecdcfc93d91dcbb0779892"},
-    {file = "pydantic-1.9.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0f047e11febe5c3198ed346b507e1d010330d56ad615a7e0a89fae604065a0e"},
-    {file = "pydantic-1.9.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:969dd06110cb780da01336b281f53e2e7eb3a482831df441fb65dd30403f4608"},
-    {file = "pydantic-1.9.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:177071dfc0df6248fd22b43036f936cfe2508077a72af0933d0c1fa269b18537"},
-    {file = "pydantic-1.9.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:9bcf8b6e011be08fb729d110f3e22e654a50f8a826b0575c7196616780683380"},
-    {file = "pydantic-1.9.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a955260d47f03df08acf45689bd163ed9df82c0e0124beb4251b1290fa7ae728"},
-    {file = "pydantic-1.9.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9ce157d979f742a915b75f792dbd6aa63b8eccaf46a1005ba03aa8a986bde34a"},
-    {file = "pydantic-1.9.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0bf07cab5b279859c253d26a9194a8906e6f4a210063b84b433cf90a569de0c1"},
-    {file = "pydantic-1.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d93d4e95eacd313d2c765ebe40d49ca9dd2ed90e5b37d0d421c597af830c195"},
-    {file = "pydantic-1.9.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1542636a39c4892c4f4fa6270696902acb186a9aaeac6f6cf92ce6ae2e88564b"},
-    {file = "pydantic-1.9.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a9af62e9b5b9bc67b2a195ebc2c2662fdf498a822d62f902bf27cccb52dbbf49"},
-    {file = "pydantic-1.9.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fe4670cb32ea98ffbf5a1262f14c3e102cccd92b1869df3bb09538158ba90fe6"},
-    {file = "pydantic-1.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:9f659a5ee95c8baa2436d392267988fd0f43eb774e5eb8739252e5a7e9cf07e0"},
-    {file = "pydantic-1.9.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b83ba3825bc91dfa989d4eed76865e71aea3a6ca1388b59fc801ee04c4d8d0d6"},
-    {file = "pydantic-1.9.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1dd8fecbad028cd89d04a46688d2fcc14423e8a196d5b0a5c65105664901f810"},
-    {file = "pydantic-1.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02eefd7087268b711a3ff4db528e9916ac9aa18616da7bca69c1871d0b7a091f"},
-    {file = "pydantic-1.9.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7eb57ba90929bac0b6cc2af2373893d80ac559adda6933e562dcfb375029acee"},
-    {file = "pydantic-1.9.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:4ce9ae9e91f46c344bec3b03d6ee9612802682c1551aaf627ad24045ce090761"},
-    {file = "pydantic-1.9.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:72ccb318bf0c9ab97fc04c10c37683d9eea952ed526707fabf9ac5ae59b701fd"},
-    {file = "pydantic-1.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:61b6760b08b7c395975d893e0b814a11cf011ebb24f7d869e7118f5a339a82e1"},
-    {file = "pydantic-1.9.1-py3-none-any.whl", hash = "sha256:4988c0f13c42bfa9ddd2fe2f569c9d54646ce84adc5de84228cfe83396f3bd58"},
-    {file = "pydantic-1.9.1.tar.gz", hash = "sha256:1ed987c3ff29fff7fd8c3ea3a3ea877ad310aae2ef9889a119e22d3f2db0691a"},
-]
+pydantic = []
 pyflakes = []
 python-barcode = []
 python-dateutil = []
 python-decouple = []
-qrcode = [
-    {file = "qrcode-7.3.1.tar.gz", hash = "sha256:375a6ff240ca9bd41adc070428b5dfc1dcfbb0f2507f1ac848f6cded38956578"},
-]
-requests = [
-    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
-    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
-]
+qrcode = []
+requests = []
 responses = []
 six = []
 toml = []
-tomli = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-typing-extensions = [
-    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
-    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
-]
-unidecode = [
-    {file = "Unidecode-1.3.4-py3-none-any.whl", hash = "sha256:afa04efcdd818a93237574791be9b2817d7077c25a068b00f8cff7baa4e59257"},
-    {file = "Unidecode-1.3.4.tar.gz", hash = "sha256:8e4352fb93d5a735c788110d2e7ac8e8031eb06ccbfe8d324ab71735015f9342"},
-]
-urllib3 = [
-    {file = "urllib3-1.26.11-py2.py3-none-any.whl", hash = "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc"},
-    {file = "urllib3-1.26.11.tar.gz", hash = "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"},
-]
+tomli = []
+typing-extensions = []
+unidecode = []
+urllib3 = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ coverage = {extras = ["toml"], version = "^5.5"}
 isort = "^5.9.2"
 freezegun = "1.1.0"
 responses = "^0.21.0"
+py-bdd-context = "^0.0.2"
 
 [tool.poetry.scripts]
 

--- a/tests/wrapper/test_request.py
+++ b/tests/wrapper/test_request.py
@@ -101,6 +101,8 @@ class RequestsWrapperTestCase(TestCase):
             - o ConnectionResetError é lançado
         Então:
             - a requisição deve ocorrer com sucesso
+            - devem ter sido realizadas 4 requisições
+              (3 tentativas falhas e 1 bem sucedida)
         """
         self.headers_patcher = patch(
             "bb_wrapper.wrapper.request.RequestsWrapper._get_request_info"
@@ -122,7 +124,7 @@ class RequestsWrapperTestCase(TestCase):
         url = "https://httpstat.us/200?sleep=1"
         wrapper._get(url)
         
-        self.assertEqual(self.mocked_headers.call_count, 3)
+        self.assertEqual(self.mocked_headers.call_count, 4)
 
         self.headers_patcher.stop()
 
@@ -134,6 +136,7 @@ class RequestsWrapperTestCase(TestCase):
             - o ConnectionResetError é lançado
         Então:
             - o erro de conexão deve ser lançado
+              (4 tentativas falhas)
         """
         self.headers_patcher = patch(
             "bb_wrapper.wrapper.request.RequestsWrapper._get_request_info"
@@ -149,6 +152,7 @@ class RequestsWrapperTestCase(TestCase):
         url = "https://httpstat.us/200?sleep=1"
         with self.assertRaises(ConnectionResetError):
             wrapper._get(url)
-        self.assertEqual(self.mocked_headers.call_count, 3)
+
+        self.assertEqual(self.mocked_headers.call_count, 4)
 
         self.headers_patcher.stop()

--- a/tests/wrapper/test_request.py
+++ b/tests/wrapper/test_request.py
@@ -147,5 +147,6 @@ class RequestsWrapperTestCase(TestCase):
         url = "https://httpstat.us/200?sleep=1"
         with self.assertRaises(ConnectionResetError):
             wrapper._get(url)
+        self.assertEqual(self.mocked_headers.call_count, 3)
 
         self.headers_patcher.stop()

--- a/tests/wrapper/test_request.py
+++ b/tests/wrapper/test_request.py
@@ -121,6 +121,8 @@ class RequestsWrapperTestCase(TestCase):
         wrapper = RequestsWrapper(base_url="")
         url = "https://httpstat.us/200?sleep=1"
         wrapper._get(url)
+        
+        self.assertEqual(self.mocked_headers.call_count, 3)
 
         self.headers_patcher.stop()
 

--- a/tests/wrapper/test_request.py
+++ b/tests/wrapper/test_request.py
@@ -1,158 +1,203 @@
-from unittest import TestCase
-
 from unittest.mock import patch
 from requests import Timeout
+from py_bdd_context import BDDContextTestCase
 
 from bb_wrapper.wrapper.request import RequestsWrapper
 
 
-class RequestsWrapperTestCase(TestCase):
+class RequestsWrapperTestCase(BDDContextTestCase):
     maxDiff = None
 
     def test_contruct_url_1(self):
-        """
-        Dado:
+        with self.given(
+            """
             - uma base_url 'http://foo.bar'
             - um wrapper RequestsWrapper(self.base_url)
-        Quando:
+            """
+        ):
+            base_url = "http://foo.bar"
+            wrapper = RequestsWrapper(base_url=base_url)
+
+        with self.when(
+            """
             - self.wrapper._construct_url('acao1', 'id1', 'subacao2', 'id2')
-        Então:
+            """
+        ):
+            result = wrapper._construct_url("acao1", "id1", "subacao2", "id2")
+
+        with self.then(
+            """
             - o resultado deve ser "http://foo.bar/acao1/id1/subacao2/id2"
-        """
-        base_url = "http://foo.bar"
-        wrapper = RequestsWrapper(base_url=base_url)
+            """
+        ):
+            expected = "http://foo.bar/acao1/id1/subacao2/id2"
 
-        result = wrapper._construct_url("acao1", "id1", "subacao2", "id2")
-
-        expected = "http://foo.bar/acao1/id1/subacao2/id2"
-
-        self.assertEqual(result, expected)
+            self.assertEqual(result, expected)
 
     def test_contruct_url_2(self):
-        """
-        Dado:
+        with self.given(
+            """
             - uma base_url 'http://foo.bar'
             - um wrapper RequestsWrapper(self.base_url)
-        Quando:
+            """
+        ):
+            base_url = "http://foo.bar"
+            wrapper = RequestsWrapper(base_url=base_url)
+        with self.when(
+            """
             - self.wrapper._construct_url('acao1', 'id1', 'subacao2', 'id2', search='query1=1&query2=2')  # noqa
-        Então:
+            """
+        ):
+            result = wrapper._construct_url(
+                "acao1", "id1", "subacao2", "id2", search="query1=1&query2=2"
+            )
+
+        with self.then(
+            """
             - o resultado deve ser "http://foo.bar/acao1/id1/subacao2/id2?query1=1&query2=2"  # noqa
-        """
-        base_url = "http://foo.bar"
-        wrapper = RequestsWrapper(base_url=base_url)
+            """
+        ):
+            expected = "http://foo.bar/acao1/id1/subacao2/id2?query1=1&query2=2"
 
-        result = wrapper._construct_url(
-            "acao1", "id1", "subacao2", "id2", search="query1=1&query2=2"
-        )
-
-        expected = "http://foo.bar/acao1/id1/subacao2/id2?query1=1&query2=2"
-
-        self.assertEqual(result, expected)
+            self.assertEqual(result, expected)
 
     def test_contruct_url_3(self):
-        """
-        Dado:
+        with self.given(
+            """
             - uma base_url 'http://foo.bar'
             - um wrapper RequestsWrapper(self.base_url)
-        Quando:
+            """
+        ):
+            base_url = "http://foo.bar"
+            wrapper = RequestsWrapper(base_url=base_url)
+
+        with self.when(
+            """
             - self.wrapper._construct_url('acao1', 'id1', 'subacao2', 'id2', search=dict(query1=1, query2=2))  # noqa
-        Então:
+            """
+        ):
+            result = wrapper._construct_url(
+                "acao1", "id1", "subacao2", "id2", search=dict(query1=1, query2=2)
+            )
+
+        with self.then(
+            """
             - o resultado deve ser "http://foo.bar/acao1/id1/subacao2/id2?query1=1&query2=2"  # noqa
-        """
-        base_url = "http://foo.bar"
-        wrapper = RequestsWrapper(base_url=base_url)
+            """
+        ):
+            expected = "http://foo.bar/acao1/id1/subacao2/id2?query1=1&query2=2"
 
-        result = wrapper._construct_url(
-            "acao1", "id1", "subacao2", "id2", search=dict(query1=1, query2=2)
-        )
-
-        expected = "http://foo.bar/acao1/id1/subacao2/id2?query1=1&query2=2"
-
-        self.assertEqual(result, expected)
+            self.assertEqual(result, expected)
 
     def test_request_timeout(self):
-        """
-        Dado:
+        with self.given(
+            """
             - uma requisição qualquer
-        Quando:
+            """
+        ):
+            self.headers_patcher = patch(
+                "bb_wrapper.wrapper.request.RequestsWrapper._get_request_info"
+            )
+            self.mocked_headers = self.headers_patcher.start()
+
+            self.mocked_headers.return_value = {}
+
+            wrapper = RequestsWrapper(base_url="", timeout=2)
+
+        with self.when(
+            """
             - o servidor demorar X segundos para responder
-        Então:
+            """
+        ):
+            url = "https://httpstat.us/200?sleep=5000"
+            with self.assertRaises(Timeout):
+                wrapper._get(url)
+
+        with self.then(
+            """
             - um erro de timeout deve ser lançado
-        """
-        self.headers_patcher = patch(
-            "bb_wrapper.wrapper.request.RequestsWrapper._get_request_info"
-        )
-        self.mocked_headers = self.headers_patcher.start()
-
-        self.mocked_headers.return_value = {}
-
-        wrapper = RequestsWrapper(base_url="", timeout=2)
-        url = "https://httpstat.us/200?sleep=5000"
-        with self.assertRaises(Timeout):
-            wrapper._get(url)
-
-        self.headers_patcher.stop()
+            """
+        ):
+            self.headers_patcher.stop()
 
     def test_retry_request(self):
-        """
-        Dado:
+        with self.given(
+            """
             - uma requisição qualquer
-        Quando:
+            """
+        ):
+            self.headers_patcher = patch(
+                "bb_wrapper.wrapper.request.RequestsWrapper._get_request_info"
+            )
+            self.mocked_headers = self.headers_patcher.start()
+
+            max_retries = 3
+
+            def raise_connection_reset_error(headers=None):
+                call_count = self.mocked_headers.call_count
+                if call_count <= max_retries:
+                    raise ConnectionResetError
+                else:
+                    return dict()
+
+            self.mocked_headers.side_effect = raise_connection_reset_error
+
+            wrapper = RequestsWrapper(base_url="")
+            url = "https://httpstat.us/200?sleep=1"
+
+        with self.when(
+            """
+            - a requisição é realizada
             - o ConnectionResetError é lançado
-        Então:
+            """
+        ):
+            wrapper._get(url)
+
+        with self.then(
+            """
             - a requisição deve ocorrer com sucesso
             - devem ter sido realizadas 4 requisições
               (3 tentativas falhas e 1 bem sucedida)
-        """
-        self.headers_patcher = patch(
-            "bb_wrapper.wrapper.request.RequestsWrapper._get_request_info"
-        )
-        self.mocked_headers = self.headers_patcher.start()
+            """
+        ):
+            self.assertEqual(self.mocked_headers.call_count, 4)
 
-        max_retries = 3
-
-        def raise_connection_reset_error(headers=None):
-            call_count = self.mocked_headers.call_count
-            if call_count <= max_retries:
-                raise ConnectionResetError
-            else:
-                return dict()
-
-        self.mocked_headers.side_effect = raise_connection_reset_error
-
-        wrapper = RequestsWrapper(base_url="")
-        url = "https://httpstat.us/200?sleep=1"
-        wrapper._get(url)
-        
-        self.assertEqual(self.mocked_headers.call_count, 4)
-
-        self.headers_patcher.stop()
+            self.headers_patcher.stop()
 
     def test_fail_retry_request(self):
-        """
-        Dado:
+        with self.given(
+            """
             - uma requisição qualquer
-        Quando:
+            """
+        ):
+            self.headers_patcher = patch(
+                "bb_wrapper.wrapper.request.RequestsWrapper._get_request_info"
+            )
+            self.mocked_headers = self.headers_patcher.start()
+
+            def raise_connection_reset_error(headers=None):
+                raise ConnectionResetError
+
+            self.mocked_headers.side_effect = raise_connection_reset_error
+
+            wrapper = RequestsWrapper(base_url="")
+            url = "https://httpstat.us/200?sleep=1"
+
+        with self.when(
+            """
+            - a requisição é realizada
             - o ConnectionResetError é lançado
-        Então:
+            """
+        ):
+            with self.assertRaises(ConnectionResetError):
+                wrapper._get(url)
+
+        with self.then(
+            """
             - o erro de conexão deve ser lançado
               (4 tentativas falhas)
-        """
-        self.headers_patcher = patch(
-            "bb_wrapper.wrapper.request.RequestsWrapper._get_request_info"
-        )
-        self.mocked_headers = self.headers_patcher.start()
+            """
+        ):
+            self.assertEqual(self.mocked_headers.call_count, 4)
 
-        def raise_connection_reset_error(headers=None):
-            raise ConnectionResetError
-
-        self.mocked_headers.side_effect = raise_connection_reset_error
-
-        wrapper = RequestsWrapper(base_url="")
-        url = "https://httpstat.us/200?sleep=1"
-        with self.assertRaises(ConnectionResetError):
-            wrapper._get(url)
-
-        self.assertEqual(self.mocked_headers.call_count, 4)
-
-        self.headers_patcher.stop()
+            self.headers_patcher.stop()


### PR DESCRIPTION
# Resumo
<!-- Issues/prs relacionados, caso tenha -->
Relacionado aos issues/prs:

- 

<!-- Uma breve descrição do problema -->
Algumas requisições a APIs de terceiros resultaram em erros de conexão com a seguinte mensagem: "Connection reset by peer".

Este PR corrige esse erro adicionando o decorator `retry_request`, com sleep de 0.01 segundos, para que a comunicação com a API BB seja reestabelecida.


# Alterações de models
- [ ] Sim
- [x] Não

<!-- Alguma descrição dos models alterados -->


# Alterações de services
- [ ] Sim
- [x] Não

<!-- Alguma descrição dos services alterados -->


# Alterações de wrappers
- [x] Sim
- [ ] Não

<!-- Alguma descrição dos wrappers alterados -->
Adiciona decorator `retry_request` para os métodos http da classe RequestWrapper.