### PR TITLE
Adiciona copy/paste para desenvolvimento local

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,10 @@ Certifique-se que o ambiente está ativado, se não estiver execute:
 
 .. code-block:: bash
 
+    nix develop
+
+.. code-block:: bash
+
     nix flake clone 'github:imobanco/bb-wrapper' --dest bb-wrapper \
     && cd bb-wrapper 1>/dev/null 2>/dev/null \
     && (direnv --version 1>/dev/null 2>/dev/null && direnv allow) \

--- a/README.rst
+++ b/README.rst
@@ -93,3 +93,7 @@ Certifique-se que o ambiente está ativado, se não estiver execute:
     && (direnv --version 1>/dev/null 2>/dev/null && direnv allow) \
     || nix develop --command sh -c 'make poetry.config.venv && make poetry.install && python -c "import requests"'
 
+    git remote set-url origin $(git remote show origin \
+        | grep "Fetch URL" \
+        | sed 's/ *Fetch URL: //' \
+        | sed 's/https:\/\/github.com\//git@github.com:/')

--- a/README.rst
+++ b/README.rst
@@ -84,5 +84,8 @@ Certifique-se que o ambiente está ativado, se não estiver execute:
 
 .. code-block:: bash
 
-    nix develop
+    nix flake clone 'github:imobanco/bb-wrapper' --dest bb-wrapper \
+    && cd bb-wrapper 1>/dev/null 2>/dev/null \
+    && (direnv --version 1>/dev/null 2>/dev/null && direnv allow) \
+    || nix develop --command sh -c 'make poetry.config.venv && make poetry.install && python -c "import requests"'
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1629481132,
-        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1629485646,
-        "narHash": "sha256-m/BhLkERvJv1LWEZAHISSzRPgyikQ0X6XjVRh2sFv10=",
-        "owner": "NixOS",
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8391951d5d1286a97f63c166bfd9312ae5627ef5",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
         "type": "github"
       },
       "original": {
@@ -33,6 +36,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
             # ativa o .venv.
             # Notar que pode haver dessincronia por conta de
             # um .venv desatualizado.
-            test -f .venv/bin/activate || make poetry.install
+            test -f .venv/bin/activate || make poetry.config.venv && make poetry.install
             source .venv/bin/activate
             # Se não existir cria o .env com valores padrão
             if ! test -f .env; then


### PR DESCRIPTION
## Resumo

Esse PR:
- Adiciona copy/paste para desenvolvimento local;
- Atualiza a versão do `nixpkgs` utilizada para uma bem mais recente, commit ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b;
- Corrige criação do ambiente virtual para o ambiente de desenvolvimento. 

### Detalhes

Existe uma diferença entre:
```bash
nix flake clone 'github:imobanco/bb-wrapper' --dest bb-wrapper
```

_vs_ 

```bash
nix flake clone 'git+ssh://git@github.com/imobanco/bb-wrapper.git' --dest bb-wrapper
```

Note: o último usa o protocolo `git+ssh`, isso pemite que seja feito push para branchs no repositório, **SE** quem está fazendo o push tiver as devidas pemissões para assim fazer. Entretanto não é possível clonar inicialmente usando `git+ssh` se quem está fazendo o `nix flake clone ...` não possui as credênciais de acesso.


Imagino que o fluxo mais acessível seja:
-  inicialmente clonar via `nix flake clone 'github: '...` 
- quem precisar muda para ssh, assim o faz (adicionei um segundo comando que já utilizei em vários repositórios e a bastante tempo)

Refs.:
- https://discourse.nixos.org/t/nix-flake-and-private-repository-again/16350/13

