### PR TITLE
API PIX > Ajustes e correção do ambiente de sandbox

### DIFF
--- a/bb_wrapper/wrapper/bb.py
+++ b/bb_wrapper/wrapper/bb.py
@@ -41,11 +41,11 @@ class BaseBBWrapper(RequestsWrapper):
         if gw_app_key is None:
             gw_app_key = GW_APP_KEY
 
-        self.__basic_token = basic_token
-        self.__gw_app_key = gw_app_key
+        self._basic_token = basic_token
+        self._gw_app_key = gw_app_key
         self._is_sandbox = is_sandbox
 
-        if self.__basic_token == "" or self.__gw_app_key == "":
+        if self._basic_token == "" or self._gw_app_key == "":
             raise ValueError("Configure o basic_token/gw_app_key do BB!")
 
         if self._is_sandbox:
@@ -122,7 +122,7 @@ class BaseBBWrapper(RequestsWrapper):
         else:
             url += "&"
 
-        url += f"gw-dev-app-key={self.__gw_app_key}"
+        url += f"gw-dev-app-key={self._gw_app_key}"
 
         return url
 
@@ -196,7 +196,7 @@ class BaseBBWrapper(RequestsWrapper):
         O endpoint oauth recebe application/x-www-form-urlencoded!
         """
         url = self.__oauth_url()
-        header = {"Authorization": f"Basic {self.__basic_token}"}
+        header = {"Authorization": f"Basic {self._basic_token}"}
 
         data = {
             "grant_type": "client_credentials",

--- a/bb_wrapper/wrapper/pix_cob.py
+++ b/bb_wrapper/wrapper/pix_cob.py
@@ -164,41 +164,6 @@ class PIXCobBBWrapper(BaseBBWrapper):
 
         return response
 
-    def criar_cobranca_qrcode(
-        self,
-        expiracao: int,
-        chave: str,
-        documento_devedor: str,
-        nome_devedor: str,
-        nome_recebedor: str,
-        valor: float,
-        descricao: str,
-        info: list = None,
-    ):
-        """
-        Criar uma cobrança PIX com QRCode dinâmico
-
-        Args:
-            expiracao: segundos antes da expiracao
-            chave: chave PIX
-            documento_devedor: CPF ou CNPJ
-            nome_devedor: Nome do devedor
-            nome_recebedor: Nome do recebedor
-            valor: valor da cobrança
-            descricao: descrição da cobrança
-        """
-        data = self._create_and_validate_cobranca_data(
-            expiracao, chave, documento_devedor, nome_devedor, valor, descricao, info
-        )
-
-        url = self._construct_url("cobqrcode", end_bar=True)
-
-        response = self._put(url, data)
-
-        self._injeta_qrcode_data(response, nome_recebedor)
-
-        return response
-
     def consultar_cobranca(self, txid):
         """
         Consultar uma cobrança PIX

--- a/bb_wrapper/wrapper/pix_cob.py
+++ b/bb_wrapper/wrapper/pix_cob.py
@@ -11,7 +11,7 @@ class PIXCobBBWrapper(BaseBBWrapper):
 
     SCOPE = "cob.read cob.write pix.read pix.write"
 
-    SANDBOX_BASE_URL = "https://api-pix.hm.bb.com.br/pix/v2"
+    SANDBOX_BASE_URL = "https://api.hm.bb.com.br/pix/v2"
     BASE_URL = "https://api-pix.bb.com.br/pix/v2"
 
     def listar_pix(self, inicio=None, fim=None, page=0):
@@ -31,7 +31,7 @@ class PIXCobBBWrapper(BaseBBWrapper):
         if fim:
             search["fim"] = fim
 
-        url = self._construct_url("pix", end_bar=False, search=search)
+        url = self._construct_url("pix", search=search)
 
         response = self._get(url)
 
@@ -156,7 +156,7 @@ class PIXCobBBWrapper(BaseBBWrapper):
             expiracao, chave, documento_devedor, nome_devedor, valor, descricao, info
         )
 
-        url = self._construct_url("cob", end_bar=True)
+        url = self._construct_url("cob")
 
         response = self._post(url, data)
 

--- a/bb_wrapper/wrapper/request.py
+++ b/bb_wrapper/wrapper/request.py
@@ -37,17 +37,17 @@ class RequestsWrapper:
     wrapper da lib requests
 
     Attributes:
-        __base_url: Url base para construir os requests
-        __timeout: Tempo máximo de espera de requests
+        _base_url: Url base para construir os requests
+        _timeout: Tempo máximo de espera de requests
         _verify_https: flag que ativa verificação https
-        __cert: certificado http
+        _cert: certificado http
     """
 
     def __init__(self, *args, base_url, verify_https=True, cert=None, **kwargs):
-        self.__base_url = base_url
+        self._base_url = base_url
         self._verify_https = verify_https
-        self.__cert = cert
-        self.__timeout = kwargs.get("timeout", None)
+        self._cert = cert
+        self._timeout = kwargs.get("timeout", None)
 
     @staticmethod
     def _process_response(response: requests.Response) -> requests.Response:
@@ -132,10 +132,6 @@ class RequestsWrapper:
     def _authorization_header_data(self):
         return {"Authorization": self._auth}
 
-    @property
-    def _base_url(self):
-        return self.__base_url
-
     def _get_request_info(self, headers=None):
         if not headers:
             headers = self._authorization_header_data
@@ -145,7 +141,7 @@ class RequestsWrapper:
         return dict(
             headers=headers,
             verify=self._verify_https,
-            cert=self.__cert,
+            cert=self._cert,
         )
 
     @retry_request(max_retries=3)
@@ -160,7 +156,7 @@ class RequestsWrapper:
             (:class:`.requests.Response`)
         """
         request_info = self._get_request_info(headers)
-        response = requests.delete(url, timeout=self.__timeout, **request_info)
+        response = requests.delete(url, timeout=self._timeout, **request_info)
         response = self._process_response(response)
         return response
 
@@ -176,7 +172,7 @@ class RequestsWrapper:
             (:class:`.requests.Response`)
         """
         request_info = self._get_request_info(headers)
-        response = requests.get(url, timeout=self.__timeout, **request_info)
+        response = requests.get(url, timeout=self._timeout, **request_info)
         response = self._process_response(response)
         return response
 
@@ -199,7 +195,7 @@ class RequestsWrapper:
             request_info["json"] = data
         else:
             request_info["data"] = data
-        response = requests.post(url, timeout=self.__timeout, **request_info)
+        response = requests.post(url, timeout=self._timeout, **request_info)
         response = self._process_response(response)
         return response
 
@@ -220,7 +216,7 @@ class RequestsWrapper:
             request_info["json"] = data
         else:
             request_info["data"] = data
-        response = requests.put(url, timeout=self.__timeout, **request_info)
+        response = requests.put(url, timeout=self._timeout, **request_info)
         response = self._process_response(response)
         return response
 
@@ -231,6 +227,6 @@ class RequestsWrapper:
             request_info["json"] = data
         else:
             request_info["data"] = data
-        response = requests.patch(url, timeout=self.__timeout, **request_info)
+        response = requests.patch(url, timeout=self._timeout, **request_info)
         response = self._process_response(response)
         return response

--- a/examples/pix_cob/consultar_cobranca.py
+++ b/examples/pix_cob/consultar_cobranca.py
@@ -4,9 +4,11 @@ from examples.utils import dump_response
 
 from bb_wrapper.wrapper import PIXCobBBWrapper
 
-c = PIXCobBBWrapper(cert=("./certs/cert.pem", "./certs/key.pem"))
+c = PIXCobBBWrapper(
+    cert=("./certs/cert.pem", "./certs/key.pem")
+)
 
-txid = "HUAY0i0XMbuq6W3EcGapjsGCp5V19ToaRNR"
+txid = '6lEZLwT4o1fjmg1BVW3KeIPLc0'
 
 response = c.consultar_cobranca(txid)
 

--- a/examples/pix_cob/consultar_cobranca.py
+++ b/examples/pix_cob/consultar_cobranca.py
@@ -4,11 +4,9 @@ from examples.utils import dump_response
 
 from bb_wrapper.wrapper import PIXCobBBWrapper
 
-c = PIXCobBBWrapper(
-    cert=("./certs/cert.pem", "./certs/key.pem")
-)
+c = PIXCobBBWrapper(cert=("./certs/cert.pem", "./certs/key.pem"))
 
-txid = '6lEZLwT4o1fjmg1BVW3KeIPLc0'
+txid = "6lEZLwT4o1fjmg1BVW3KeIPLc0"
 
 response = c.consultar_cobranca(txid)
 

--- a/examples/pix_cob/criar_cobrança_cpf.py
+++ b/examples/pix_cob/criar_cobrança_cpf.py
@@ -4,7 +4,9 @@ from examples.utils import dump_response
 
 from bb_wrapper.wrapper import PIXCobBBWrapper
 
-c = PIXCobBBWrapper()
+c = PIXCobBBWrapper(
+    cert=("./certs/cert.pem", "./certs/key.pem")
+)
 
 data = {
     "expiracao": 60 * 60,  # 60 segundos = 1 minuto. 60 minutos = 1h
@@ -12,7 +14,7 @@ data = {
     "nome_devedor": "Francisco da SilvaFrancisco da SilvaFrancisco da SilvaFrancisco da SilvaFrancisco da Silva",  # noqa: E501
     "valor": 130.44,
     "nome_recebedor": "Imobanco",
-    "chave": "7f6844d0-de89-47e5-9ef7-e0a35a681615",
+    "chave": "9e881f18-cc66-4fc7-8f2c-a795dbb2bfc1",
     "descricao": "Cobrança dos serviços prestados.",
     "info": [{"nome": "Sacado", "valor": "Nome do sacado aqui"}],
 }

--- a/examples/pix_cob/criar_cobrança_cpf.py
+++ b/examples/pix_cob/criar_cobrança_cpf.py
@@ -4,9 +4,7 @@ from examples.utils import dump_response
 
 from bb_wrapper.wrapper import PIXCobBBWrapper
 
-c = PIXCobBBWrapper(
-    cert=("./certs/cert.pem", "./certs/key.pem")
-)
+c = PIXCobBBWrapper(cert=("./certs/cert.pem", "./certs/key.pem"))
 
 data = {
     "expiracao": 60 * 60,  # 60 segundos = 1 minuto. 60 minutos = 1h

--- a/tests/wrapper/test_cobrancas.py
+++ b/tests/wrapper/test_cobrancas.py
@@ -250,7 +250,7 @@ class CobrancasBBWrapperTestCase(IsolatedEnvTestCase):
 
         expected = (
             "https://api.sandbox.bb.com.br/cobrancas/v2/boletos"
-            f"?gw-dev-app-key={wrapper._BaseBBWrapper__gw_app_key}"
+            f"?gw-dev-app-key={wrapper._gw_app_key}"
         )
 
         self.assertEqual(result, expected)

--- a/tests/wrapper/test_pagamentos.py
+++ b/tests/wrapper/test_pagamentos.py
@@ -32,7 +32,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         expected = (
             f"https://api.sandbox.bb.com.br/pagamentos-lote/v1/"
-            f"?gw-dev-app-key={PagamentoLoteBBWrapper()._BaseBBWrapper__gw_app_key}"
+            f"?gw-dev-app-key={PagamentoLoteBBWrapper()._gw_app_key}"
         )
 
         self.assertEqual(expected, result)
@@ -53,7 +53,7 @@ class PagamentoLoteBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase
 
         expected = (
             f"https://api-ip.bb.com.br/pagamentos-lote/v1/"
-            f"?gw-dev-app-key={PagamentoLoteBBWrapper()._BaseBBWrapper__gw_app_key}"
+            f"?gw-dev-app-key={PagamentoLoteBBWrapper()._gw_app_key}"
         )
 
         self.assertEqual(expected, result)

--- a/tests/wrapper/test_pix_cob.py
+++ b/tests/wrapper/test_pix_cob.py
@@ -172,7 +172,7 @@ class PixCobBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
         """
         result = PIXCobBBWrapper()._construct_url(end_bar=True)
 
-        expected = "https://api-pix.hm.bb.com.br/pix/v2/?gw-dev-app-key=KEY"
+        expected = "https://api.hm.bb.com.br/pix/v2/?gw-dev-app-key=KEY"
 
         self.assertIn(expected, result)
 
@@ -188,7 +188,7 @@ class PixCobBBWrapperTestCase(IsolatedEnvTestCase, MockedRequestsTestCase):
         """
         result = PIXCobBBWrapper()._construct_url(end_bar=False)
 
-        expected = "https://api-pix.hm.bb.com.br/pix/v2?gw-dev-app-key="
+        expected = "https://api.hm.bb.com.br/pix/v2?gw-dev-app-key="
         self.assertIn(expected, result)
 
     def test_consultar_cobranca_content_bizarro(self):


### PR DESCRIPTION
# Resumo

O ambiente de sandbox sem mTLS é sem o prefixo `-pix`.

![image](https://github.com/user-attachments/assets/49129ac1-05db-4807-a5fb-12fef56e800d)
