### PR TITLE
corrige paginação no PIX

### DIFF
--- a/bb_wrapper/wrapper/pix_cob.py
+++ b/bb_wrapper/wrapper/pix_cob.py
@@ -24,7 +24,7 @@ class PIXCobBBWrapper(BaseBBWrapper):
             page: número da página atual. Padrão 0
         """
         search = {
-            "paginaAtual": page,
+            "paginacao.paginaAtual": page,
         }
         if inicio:
             search["inicio"] = inicio

--- a/examples/pix_cob/listar_pix_3_paginado.py
+++ b/examples/pix_cob/listar_pix_3_paginado.py
@@ -1,0 +1,11 @@
+from bb_wrapper.wrapper import PIXCobBBWrapper
+
+c = PIXCobBBWrapper()
+
+response_1 = c.listar_pix(inicio="2024-08-13T00:00:00Z", fim="2024-08-16T23:59:59Z")
+assert response_1.data["parametros"]["paginacao"]["paginaAtual"] == 0
+
+response_2 = c.listar_pix(
+    inicio="2024-08-13T00:00:00Z", fim="2024-08-16T23:59:59Z", page=1
+)
+assert response_2.data["parametros"]["paginacao"]["paginaAtual"] == 1


### PR DESCRIPTION
# Resumo

Na versão v2 do PIX, o parâmetro de paginação do endpoint `/pix` agora é `paginacao.paginaAtual` e não mais `paginaAtual`.